### PR TITLE
blog fix

### DIFF
--- a/2019-12-09-a-year-of-blogs.md
+++ b/2019-12-09-a-year-of-blogs.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: ‘Open Street Map and MapAction post Hurricane Dorian’ - A Year of Blogs - December 2019
-postID: A-Year-Of-Blogs-Dec
+postID: a-year-of-blogs
 category: blog
 banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_2019129_banner.jpg
 date: 2019-11-27

--- a/2019-12-09-a-year-of-blogs.md
+++ b/2019-12-09-a-year-of-blogs.md
@@ -3,8 +3,8 @@ layout: post
 title: ‘Open Street Map and MapAction post Hurricane Dorian’ - A Year of Blogs - December 2019
 postID: a-year-of-blogs
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_2019129_banner.jpg
-date: 2019-11-27
+banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191209_banner.jpg
+date: 2019-12-09
 author: Alice Goudie
 excerpt: Open Street Map and MapAction post Hurricane Dorian
 published: true
@@ -19,7 +19,7 @@ A Year of Blogs - December 2019
 Hurricane Dorian hit the Bahamas at the beginning of September 2019 and MapAction volunteers were on one of the first planes to land into Nassau after the devastating storm. MapAction aims to use data and maps to help aid agencies, governments and local partners to make informed decisions and deliver aid and emergency supplies to the right place at the right time. Open Street Map data plays a critical role in helping MapAction achieve these aims when responding to a natural disaster, such as Hurricane Dorian.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps_blog_2019129_point.jpg">
+<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps_blog_20191209_point.jpg">
 <p class="caption">MapAction volunteers review a fresh resource.</p>
 </figure>
 
@@ -30,19 +30,19 @@ MapAction used OSM data in the response to hurricane Dorian in three main ways:
 -	In the absence of any other national mapping datasets 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps_blog_2019129__building_damage.jpeg">
+<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps_blog_20191209_building_damage.jpeg">
 <p class="caption">Count and percentage of buildings destroyed across Grand Bahama and Abaco.</p>
 </figure>
 
 OSM data is great because it is easy to download in a uniform format across the globe, which means that we can write scripts to automate some of our processes regardless of where in the world we are using the data.  In the case of Hurricane Dorian this meant that we could start to create maps before we even left the UK which really helped in the first few days of the response and gave us more time to work on finding more data and producing further products to ensure that the aid got to where it was needed most. The currency of the data and coverage also means it can be used in the absence of, or to supplement national datasets and can be a life saver in areas with limited data. In the case of Dorian, there were many small islands, cays and settlements, some of which were not named in other datasets. By finding them in OSM we could pass the location information on to other agencies which allowed them to find and deliver aid to isolated communities. We also then fed the data back to the national agency so that they had a more complete dataset for the future.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps_blog_2019129_roads_settlements_grand_bahama.jpeg">
+<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps_blog_20191209_roads_settlements_grand_bahama.jpeg">
 <p class="caption">Roads and Settlements in Grand Bahama.</p>
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps_blog_2019129_referencewall.jpg">
+<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps_blog_20191209_referencewall.jpg">
 <p class="caption">Checking out the Reference Map Wall.</p>
 </figure>
 

--- a/2019-12-09-a-year-of-blogs.md
+++ b/2019-12-09-a-year-of-blogs.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: ‘Open Street Map and MapAction post Hurricane Dorian’ - A Year of Blogs - December 2019
-postID: a-year-of-blogs
+postID: a-year-of-blogs-dec2019
 category: blog
 banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191209_banner.jpg
 date: 2019-12-09

--- a/2019-12-09-a-year-of-blogs.md
+++ b/2019-12-09-a-year-of-blogs.md
@@ -13,9 +13,6 @@ permalink: /blog/:year/:month/:day/:title/
 lang: en
 ---
 
-**Open Street Map and MapAction post Hurricane Dorian**
-A Year of Blogs - December 2019
-
 Hurricane Dorian hit the Bahamas at the beginning of September 2019 and MapAction volunteers were on one of the first planes to land into Nassau after the devastating storm. MapAction aims to use data and maps to help aid agencies, governments and local partners to make informed decisions and deliver aid and emergency supplies to the right place at the right time. Open Street Map data plays a critical role in helping MapAction achieve these aims when responding to a natural disaster, such as Hurricane Dorian.
 
 <figure>


### PR DESCRIPTION
- blog filename was not following standards
   - should be all lowercase
   - date should be YYYY-MM-DD
   - needs a `.md` extension
- one image file resized from 1.1MB to 115KB (still 776x1200 pixels)
- date in image file names standardized from `2019129` to `20191209` 
- blog page displays the title at the top, so no need to repeat the title at the start of the blog body text