### PR TITLE
Changing urls to images

### DIFF
--- a/2017-12-08-TY_GW17.md
+++ b/2017-12-08-TY_GW17.md
@@ -3,7 +3,7 @@ layout: post
 title: Thank You! – GeoWeek 2017
 postID: TY-GW17
 category: blog
-banner: http://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_2017128_NatGeo.jpg
+banner: https://raw.githubusercontent.com/MissingMaps/img/main/images/missingmaps-blog_20171208_banner_NatGeo.jpg
 date: 2017-12-08
 author: Rachel Levine
 excerpt: Thank you for your incredible efforts organizing this year's OSM GeoWeek!

--- a/2019-12-09-a-year-of-blogs.md
+++ b/2019-12-09-a-year-of-blogs.md
@@ -16,7 +16,7 @@ lang: en
 Hurricane Dorian hit the Bahamas at the beginning of September 2019 and MapAction volunteers were on one of the first planes to land into Nassau after the devastating storm. MapAction aims to use data and maps to help aid agencies, governments and local partners to make informed decisions and deliver aid and emergency supplies to the right place at the right time. OpenStreetMap data plays a critical role in helping MapAction achieve these aims when responding to a natural disaster, such as Hurricane Dorian.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps_blog_20191209_point.jpg">
+<img src="https://raw.githubusercontent.com/MissingMaps/img/main/images/missingmaps-blog_20191209_point.jpg">
 <p class="caption">MapAction volunteers review a fresh resource.</p>
 </figure>
 
@@ -27,19 +27,19 @@ MapAction used OSM data in the response to hurricane Dorian in three main ways:
 -	In the absence of any other national mapping datasets 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps_blog_20191209_building_damage.jpeg">
+<img src="https://raw.githubusercontent.com/MissingMaps/img/main/images/missingmaps-blog_20191209_building_damage.jpeg">
 <p class="caption">Count and percentage of buildings destroyed across Grand Bahama and Abaco.</p>
 </figure>
 
 OSM data is great because it is easy to download in a uniform format across the globe, which means that we can write scripts to automate some of our processes regardless of where in the world we are using the data.  In the case of Hurricane Dorian this meant that we could start to create maps before we even left the UK which really helped in the first few days of the response and gave us more time to work on finding more data and producing further products to ensure that the aid got to where it was needed most. The currency of the data and coverage also means it can be used in the absence of, or to supplement national datasets and can be a life saver in areas with limited data. In the case of Dorian, there were many small islands, cays and settlements, some of which were not named in other datasets. By finding them in OSM we could pass the location information on to other agencies which allowed them to find and deliver aid to isolated communities. We also then fed the data back to the national agency so that they had a more complete dataset for the future.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps_blog_20191209_roads_settlements_grand_bahama.jpeg">
+<img src="https://raw.githubusercontent.com/MissingMaps/img/main/images/missingmaps-blog_20191209_roads_settlements_grand_bahama.jpeg">
 <p class="caption">Roads and Settlements in Grand Bahama.</p>
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps_blog_20191209_referencewall.jpg">
+<img src="https://raw.githubusercontent.com/MissingMaps/img/main/images/missingmaps-blog_20191209_referencewall.jpg">
 <p class="caption">Reference maps are checked by many organizations, including local first responders.</p>
 </figure>
 

--- a/2023-03-08-IWD-2023-interview-validators.md
+++ b/2023-03-08-IWD-2023-interview-validators.md
@@ -3,7 +3,7 @@ layout: post
 title: "Women validators share perspectives"
 postID: 2023-08-08-IWD-interviews-with-women-validators
 category: blog
-banner: https://www.missingmaps.org/img/images/missingmaps-blog-2023-03-08_IWD_banner.jpg
+banner: https://www.missingmaps.org/img/images/missingmaps-blog_20230308_IWD_banner.jpg
 date: 2023-03-08
 author: Jana Bauerová
 excerpt: "For the International Women's Day 2023, three women validators from different countries shared their unique perspectives"
@@ -20,7 +20,7 @@ Among the Missing Maps contributors, validators are few and they are instrumenta
 ## Honey Grace Fombuena, Member and Volunteer at OSM Philippines and GIS Associate with Open Mapping Hub Asia Pacific, Philippines
 
 <figure>
-<img src="https://www.missingmaps.org/img/images/missingmaps-blog-2023-03-08_IWD_Honey.png">
+<img src="https://www.missingmaps.org/img/images/missingmaps-blog_20230308_IWD_Honey.png">
 <p class="caption">Honey Grace Fombuena, member and volunteer at OSM Philippines and GIS Associate with Open Mapping Hub Asia Pacific
 </p>
 </figure>
@@ -40,7 +40,7 @@ I would like to motivate them to look at validation as an opportunity to be a me
 ## Sophie Gélinas-Gagné, GIS Officer at the Canadian Red Cross, Canada
 
 <figure>
-<img src="https://www.missingmaps.org/img/images/missingmaps-blog-2023-03-08_IWD_Sophie.png">
+<img src="https://www.missingmaps.org/img/images/missingmaps-blog_20230308_IWD_Sophie.png">
 <p class="caption">Sophie Gélinas-Gagné, GIS Officer at the Canadian Red Cross
 </p>
 </figure>
@@ -64,7 +64,7 @@ For the Türkiye/Syria Earthquake Responses mapping campaign for example, the co
 ## Sabine Hiller, HOT global validator, Westport, Ireland
 
 <figure>
-<img src="https://www.missingmaps.org/img/images/missingmaps-blog-2023-03-08_IWD_Sabine.png">
+<img src="https://www.missingmaps.org/img/images/missingmaps-blog_20230308_IWD_Sabine.png">
 <p class="caption">Sabine Hiller's screen when validating HOT Tasking Manager tasks in JOSM
 </p>
 </figure>


### PR DESCRIPTION
Renaming images from three blogs to match naming convention - making the sorting of images easier.
Changing the paths to the new names of images in the following blog posts: 
- 2017-12-08-TY_GW17.md
- 2019-12-09-a-year-of-blogs.md
- 2023-03-08-IWD-2023-interview-validators.md