### PR TITLE
Update AWS image links to GitHub

### DIFF
--- a/2015-09-15-fire-sensor.md
+++ b/2015-09-15-fire-sensor.md
@@ -3,7 +3,7 @@ layout: post
 title: Fire Sensor Project
 postID: fire-sensor-project
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20150915_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20150915_banner.jpg
 date: 2015-09-15
 author: Drishtie Patel, Dan Joseph
 excerpt: "Khayelitsha is home to roughly 400,000 people, covering an area of 39 square km that includes some older \"formal\" areas and a majority of newer, informal settlements. Red Cross partners have been working in the area and looked into the major concerns the community is facing. Fires are at the top of the list. Red Cross partners are piloting a project to solve this issue &#58; a low-cost, meshed network of smart home sensors affixed to each home within the informal settlement. The American Red Cross GIS team recently set out to Khayelitsha to support the community in mapping the area for better program planning and decision making."
@@ -18,7 +18,7 @@ lang: en
 Nicely conditioned roads, beautiful beaches, cliffs, scenic bays, promenades, and hillside communities is what you think of when you hear Cape Town. However, a couple kilometers away from these spectacular sceneries and coastlines is Khayelitsha, a partially informal township reputed to be the largest and fastest growing township in South Africa. It’s a humbling sight to see.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20150915_khayelitsha-elyob.jpg" alt="Khayelitsha">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20150915_khayelitsha-elyob.jpg" alt="Khayelitsha">
 <p class="caption">Khayelitsha, CC BY-SA <a href="https://www.flickr.com/photos/elyob" target="\_blank">elyob</a></p>
 </figure>
 
@@ -35,7 +35,7 @@ Just a few days before the mapping was to start we were advised not to use smart
 Early on a very chilly morning we headed to the Andile Msizi Community Center in Khayelitsha with the South African Red Cross team. We met 34 volunteers and started a two-day training to introduce the volunteers to OpenStreetMap and the community mapping process. Volunteers were from the local area and immediately got hooked on the OSM iD editor looking at the satellite imagery of their neighborhoods and pointing out where they live.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20150915_khayelitsha.jpg" alt="Khayelitsha">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20150915_khayelitsha.jpg" alt="Khayelitsha">
 <p class="caption">Navigating the narrow paths between houses, CC-BY American Red Cross</p>
 </figure>
 
@@ -46,21 +46,21 @@ At the Community Center the group had insightful discussions, learned how to use
 Our cozy days indoors ended as we headed out to start collecting data. Teams of 4-5 volunteers were escorted by community leaders and Red Cross staff into the section chosen for the day. We equipped our volunteers with Field Papers and Garmin GPS units to collect data and GPX tracks. The area is very dense and has no centralized plan or regular layout, and structures are generally small and non-rectangular.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20150915_volunteers.jpg" alt="Volunteers">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20150915_volunteers.jpg" alt="Volunteers">
 <p class="caption">Volunteers verifying their position, CC-BY American Red Cross</p>
 </figure>
 
 Remote tracing was completed ahead of time by digital humanitarians and was hugely beneficial, giving us a fairly accurate foundation of data. The tracing was possible thanks to recent, high-resolution imagery from [Mapgive](http://mapgive.state.gov). Map literacy can be a challenge for volunteers, and the better base map made the community mapping an easier process. The GPS devices were loaded with the Field Papers' grid and the OpenStreetMap base map to help with navigation.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20150915_garmin.jpg" alt="Garmin">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20150915_garmin.jpg" alt="Garmin">
 <p class="caption">Garmin loaded with custom OSM data, CC-BY American Red Cross</p>
 </figure>
 
 After some initial fieldwork, we were able to use the GPX tracks from teams walking through the area to check the alignment of our two sources of satellite imagery (Bing and the very recently captured NextView imagery obtained through MapGive). It showed the MapGive imagery to be more accurately geo-referenced so we decided to adjust the OSM data to match the GPX tracks and MapGive imagery. Volunteers had time to re-visit some areas after the alignment of OSM data, but since the map tiles would not refresh quickly enough for new Field Papers, we created custom atlas pages with downloaded OSM data styled in QGIS. This worked out great to fill in gaps after the first round of mapping on the ground.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20150915_gpx.jpg" alt="GPX tracks of mapping teams">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20150915_gpx.jpg" alt="GPX tracks of mapping teams">
 </figure>
 
 Field data collection focused on: editing outlines of buildings (combining, dividing, adding, and removing); adding the path network; adding amenities such as places of worship, shops, and taverns; adding features that were impossible to trace from satellite imagery such as electricity transformers, narrow rows of latrines, and water taps; and adding building numbers.

--- a/2016-03-29-riohacha-colombia.md
+++ b/2016-03-29-riohacha-colombia.md
@@ -3,7 +3,7 @@ layout: post
 title: Community mapping in Riohacha, Colombia
 postID: riohacha-mapping
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160329_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160329_banner.jpg
 date: 2016-03-29
 author: Drishtie Patel, Matt Gibb
 excerpt: Every year in the Americas more and more people are living in conditions of vulnerability to natural hazards and climate change. To help reduce disaster risk and enhance community resilience in the region, the American Red Cross is working with Red Cross partners like the Colombian Red Cross to address local hazards and vulnerabilities in dozens of disaster-prone communities.
@@ -24,7 +24,7 @@ We were absolutely amazed at the responsiveness of the staff and volunteers and 
 Every year in the Americas more and more people are living in conditions of vulnerability to natural hazards and climate change. To help reduce disaster risk and enhance community resilience in the region, the American Red Cross is working with Red Cross partners to address local hazards and vulnerabilities in dozens of disaster-prone communities. Through research and community discussion in the chosen communities the Colombian Red Cross has identified the top priorities for building resilience: Community health, water and sanitation, risk reduction, organizational strengthening, rights and advocacy, mitigation microproject and risk reduction.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160329_Nuevo-Milenio.jpg" alt="Nuevo Milenio">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160329_Nuevo-Milenio.jpg" alt="Nuevo Milenio">
 <p class="caption">Nuevo Milenio – one of the mapping locations in Riohacha. CC-BY American Red Cross.</p>
 </figure>
 
@@ -33,7 +33,7 @@ Every year in the Americas more and more people are living in conditions of vuln
 The American Red Cross team held mapathons in New York with JP Morgan Chase employees, and volunteers from Washington, DC and Bogota, Colombia using satellite imagery to remotely trace the area. With the recent imagery from Mapgive so we could have a more accurate understanding of what we were going to see in the ground.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160329_JPMC-mapathon.jpg" alt="JPMC mapathon">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160329_JPMC-mapathon.jpg" alt="JPMC mapathon">
 <p class="caption"> JP Morgan Chase employees at a mapathon in New York City remotely tracing for Colombia. CC-BY American Red Cross.</p>
 </figure>
 
@@ -46,14 +46,14 @@ As we do on all our trips we used the first day to visit each of the field sites
 The RITA program managers were excited to get the training underway and have as much time for field mapping as possible. We spent two days in a hotel conference room developing the [OpenMapKit](http://openmapkit.org/) survey form and training the volunteers how to edit with [OpensStreetMap](http://www.openstreetmap.org/) and how to collect data using [Field Papers](http://fieldpapers.org/) and mobile phones. All of the volunteers and CRC staff were engaged and quick to pick up the topics we were discussing. The language barrier was one of our main challenges. The trainers did not speak Spanish and the trainees did not speak English. While Alvaro Barros, our translator was an irreplaceable asset, not being able to communicate in a manner that flowed did significantly slow the training process down. Luckily this young group of enthusiastic volunteers met us half way and we were able to work around the challenge and pick up new words as each day passed.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160329_community-needs.jpg" alt="Community needs discussion">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160329_community-needs.jpg" alt="Community needs discussion">
 <p class="caption">Group discussions about community needs. Volunteer groups use large base maps of the area to start adding major points of interest and gain confidence in their map literacy. CC-BY American Red Cross.</p>
 </figure>
 
 By the second training day the group had successfully mapped the area surrounding the hotel we were training in during their practice session. Early on the third morning we met at the Red Cross office and took a big school bus over to the areas. We grouped up, got our lunch bags for the day and set out to map two districts namely Nuevo Milenio and Villa Keiner. Due to the weather conditions, we wanted to make sure the volunteers had an early start, so they would not be working during the hottest part of the day. As we go around and check on each team, the CRC staff does the same with a Garmin Virb attached to the car that is driving through every street. The camera is set to take pictures every 3 seconds which we then upload to [Mapillary](https://www.mapillary.com/map).
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160329_checking-location.jpg" alt="Field mapping">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160329_checking-location.jpg" alt="Field mapping">
 <p class="caption">Checking a team's location in the field while mapping. CC-BY American Red Cross.</p>
 </figure>
 
@@ -62,7 +62,7 @@ Thanks to the amazing work being done by Cruz Roja Colombiana in these communiti
 At the end of each day in the field, we upload and check data the volunteers collected on the phones so we can address any issues the next day. We upload pictures to mapillary, charge phones and extra battery packs and prep FieldPapers for our groups.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160329_prep.jpg" alt="Preparation for field mapping">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160329_prep.jpg" alt="Preparation for field mapping">
 <p class="caption">Preparation for data collection in the field. CC-BY American Red Cross.</p>
 </figure>
 
@@ -71,7 +71,7 @@ After all the data is collected in the field we regrouped at the hotel for two d
 Overall, we enjoyed making new friends in the beautiful La Guajira region of Colombia. In ten days 27 volunteers surveyed 2 350 buildings of the 20 184 that were traced by remote volunteers. We’ve uploaded more pictures from our trip [here](https://www.flickr.com/photos/126636925@N06/sets/72157664879747280).
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160329_group-picture.jpg" alt="Group picture">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160329_group-picture.jpg" alt="Group picture">
 <p class="caption">The group that mapped through the weekend. CC-BY American Red Cross.</p>
 </figure>
 
@@ -80,6 +80,6 @@ Overall, we enjoyed making new friends in the beautiful La Guajira region of Col
 After we got back from Colombia we were able to analyze the data collected by the community. The validated base data was uploaded to OSM while the project-specific data was used to create maps to assist with planning and decision-making for various disaster risk reduction programs.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160329_before-after.jpg" alt="Before and after">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160329_before-after.jpg" alt="Before and after">
 <p class="caption">Before and after.</p>
 </figure>

--- a/2016-04-25-west-africa-mapping-hub-launch.md
+++ b/2016-04-25-west-africa-mapping-hub-launch.md
@@ -3,7 +3,7 @@ layout: post
 title: Field Mapping at Scale in West Africa
 postID: west-africa-mapping-hub-launch
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160425_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160425_banner.jpg
 date: 2016-04-25
 author: Emily Eros
 excerpt: "This past year, the American Red Cross undertook its biggest field effort to date: launching a mapping hub in West Africa and training local volunteers to field map over 5,000 villages in the border regions of Liberia, Guinea, and Sierra Leone. The mapping focuses on public health resources, different aspects of vulnerability, and amenities like markets that would draw people across borders – important information to understand if another Ebola outbreak were to occur."
@@ -26,14 +26,14 @@ When the 2014 Ebola outbreak began, [HOT](https://hotosm.org/) coordinated remot
 This past year, the American Red Cross undertook its biggest field effort to date: launching a mapping hub in West Africa and training local volunteers to field map over 5,000 villages in the border regions of Liberia, Guinea, and Sierra Leone. The mapping focuses on public health resources, different aspects of vulnerability, and amenities like markets that would draw people across borders – important information to understand if another outbreak were to occur.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160425_west-africa-glance.jpg" alt="overview map">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160425_west-africa-glance.jpg" alt="overview map">
 <p class="caption">The project area includes everything shaded pink. Each tiny red dot represents a community to be mapped. CC-BY American Red Cross.</p>
 </figure>
 
 Covering an area nearly as large as Switzerland, this project was a massive effort to scale up our Missing Maps field efforts in a rural region full of technical challenges: no connectivity, extremely poor roads, lack of electricity, dispersed volunteers, varying languages, ongoing health challenges, political challenges, etc.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160425_badroad.jpg" alt="bad road">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160425_badroad.jpg" alt="bad road">
 <p class="caption">Road quality is a major issue, but our volunteers manage to make it through. Photo courtesy of Lofa Chapter Red Cross volunteer.</p>
 </figure>
 
@@ -44,7 +44,7 @@ Since November, we’ve been hard at work to figure out what exactly it takes to
 In March, we were finally ready to begin mapping. Local staff, together with the GIS team from DC, travelled to three field sites in Liberia to train local volunteers in mapping and data collection. The volunteers learned to use [OsmAnd](http://osmand.net/), [ODK Collect](https://opendatakit.org/), [OpenMapKit](http://openmapkit.org/), and paper-based tools like [FieldPapers](fieldpapers.org), then they set off on motorbikes to start visiting their target communities.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160425_planning.jpg" alt="planning">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160425_planning.jpg" alt="planning">
 <p class="caption">Red Cross volunteers prepare for field mapping in Liberia. CC-BY American Red Cross.</p>
 </figure>
 
@@ -59,7 +59,7 @@ POSM is a new tool developed for working in rural areas like West Africa. Over t
 With POSM, we can pre-download all the data for an area of interest before we travel to the field. Then, when we need to prepare for field mapping or lead a mapathon, we just power up the POSM box and wirelessly connect a phone or computer to it. POSM allows us to do all of our core tasks without an internet connection, for potentially months at a time. The software is free and open-source and available [here](https://github.com/americanredcross/posm).
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160425_headlamp-posm.jpg" alt="overview map">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160425_headlamp-posm.jpg" alt="overview map">
 <p class="caption">Left: Before POSM, tech problems meant taping FieldPapers together by headlamp. Right: With POSM, we can fix problems and prep mapping on-the-fly. CC-BY American Red Cross.</p>
 </figure>
 
@@ -68,7 +68,7 @@ With POSM, we can pre-download all the data for an area of interest before we tr
 We’ve also launched a mapping hub at the heart of the cross-border area, in Guéckédou, Guinea. The hub is a physical office space with equipment, staff, and resources to lead trainings and outreach, and to engage with the local community. The goal of the space is not just to facilitate our mapping activities, but to provide longer-term and more sustainable engagement in the area and to foster a local community of mappers.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160425_hub.jpg" alt="overview map">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160425_hub.jpg" alt="overview map">
 <p class="caption">Checking out the new hub facility before it gets set up. CC-BY American Red Cross.</p>
 </figure>
 

--- a/2016-05-05-intro-to-missing-maps.md
+++ b/2016-05-05-intro-to-missing-maps.md
@@ -3,7 +3,7 @@ layout: post
 title: Missing Maps
 postID: missing-maps
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160422_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160422_banner.jpg
 date: 2016-05-05
 author: Dale Kunce
 excerpt: Welcome to the new Missing Maps Blog. Over nearly the last two years you almost 10,000 mappers have contributed over 22 million edits, almost 3 million buildings and 300,000 km of roads. These achievements are truly amazing. The new blog will focus on sharing some of the personal stories and major events happening with Missing Maps.

--- a/2016-06-02-countrystats.md
+++ b/2016-06-02-countrystats.md
@@ -3,7 +3,7 @@ layout: post
 title: OpenStreetMap Country Stats
 postID: countrystats
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160602_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160602_banner.jpg
 date: 2016-06-02
 author: Dale Kunce
 excerpt: Building an understanding of gaps left to be mapped means understanding what and how local OSM communities have been able to map. Working with some partners we created a simple Tableau visualization that shows the growth of road data in OSM over the past eight years.
@@ -21,7 +21,7 @@ I've highlighted three countries that peaked my interest below.
 When I first looked at the stats the first thing that jumped out at me was the rapid increase of mapping data in the US. I wasn't part of the project back then so I did a little research and found out that the increase is do the [TIGER Import](http://wiki.openstreetmap.org/wiki/TIGER). Seeing these types of massive data increases helps to understand how the mapping community has grown. These changes the way that we engage local mappers and community groups.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/TIGERImportAnimation.gif" alt="TIGER Import">
+<img src="https://github.com/MissingMaps/img/blob/main/images/TIGERImportAnimation.gif" alt="TIGER Import">
 <p class="caption">TIGER Import progress CC-BY-SA OSM</p>
 </figure>
 
@@ -29,7 +29,7 @@ When I first looked at the stats the first thing that jumped out at me was the r
 My first real experience with HOT and OSM was Typhoon Haiyan in the Philippines. Remote volunteers contributed over 4.5 million map edits in just 3 months. I expected a huge spike in the road data during this period. However, after reviewing the numbers the is a small uptick in edits but its right in line with the overall organic growth of OSM data in the Philippines. The Philippines mapping community is one of the strongest and most dedicated group of mappers I know. The Philippines gets hit by an average of [20 typhoons a year](https://en.wikipedia.org/wiki/Typhoons_in_the_Philippines). Having good data is very important to helping to save lives. Many groups including the local governments have switched to using OSM as the source for maps during disasters and the Philippine mapping is at the heart of this adoption and switch. How we as the Red Cross and Missing Maps work with them is drastically different than in Guinea.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/philippines.png" alt="Philippines">
+<img src="https://github.com/MissingMaps/img/blob/main/images/philippines.png" alt="Philippines">
 <p class="caption">Philippines Stats</p>
 </figure>
 
@@ -37,7 +37,7 @@ My first real experience with HOT and OSM was Typhoon Haiyan in the Philippines.
 Guinea has a much different history of map data. Prior to the [2013 Ebola outbreak](http://www.ifrc.org/en/news-and-media/news-stories/africa/guinea/red-cross-responds-to-ebola-outbreak-in-guinea--65316/) very little road data existed. Over the 18 or so months that HOT and others were involved you can clearly see the huge uptake in road length. The Guinea mapping community is still in its early days. We at the Red Cross are working to [grow both the map and the mapping community](http://localhost:3000/blog/2016/04/25/west-africa-mapping-hub-launch/) to help create the sustainable growth that we see in places like the Philippines.  
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/guinea_stats.jpg" alt="Guinea">
+<img src="https://github.com/MissingMaps/img/blob/main/images/guinea_stats.jpg" alt="Guinea">
 <p class="caption">Guinea Stats</p>
 </figure>
 

--- a/2016-06-07-zimbabwe.md
+++ b/2016-06-07-zimbabwe.md
@@ -3,7 +3,7 @@ layout: post
 title: Water Access in Zimbabwe
 postID: zimbabwe-water
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160607_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160607_banner.jpg
 date: 2016-06-07
 author: Matt Gibb
 excerpt: Drought has been a common occurence in Southern Africa due to climate variability, driven primarily by the El Niño Southern Oscillation in the Pacific Ocean. This significantly increases the vulnerability of people living in rural areas. Since 2011, the American Red Cross has partnered with the Zimbabwe Red Cross Society, to identify and mitigate hazards, and to implement resiliency projects in the region.
@@ -20,7 +20,7 @@ I recently spent a week in Binga District, with the Zimbabwe Red Cross Society, 
 In 2014, the American Red Cross partnered with the Zimbabwe Red Cross society to extend a water pipeline in the Saba Ward of Binga District. This pipeline added an additional 15 km to an existing pipeline which stretches from Lake Kariba into Saba Ward. Schools, clinics, and communities now have access to this pipeline, and therefore access to drinkable water. Women in these communities no longer need to spend their day searching for water in a dry river bed, with no guarantee of success.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160607_pipesign.jpg" alt="Pipeline Sign">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160607_pipesign.jpg" alt="Pipeline Sign">
 <p class="caption">Sign highlighting the partners who implemented the pipeline project. CC-BY American Red Cross.</p>
 </figure>
 
@@ -31,7 +31,7 @@ In addition to the pipeline access, the [Building Resilient African Communities 
 Binga is about a three-and-a-half-hour drive from Victoria Falls. Binga District itself, is located in northwestern Zimbabwe sharing a border with Zambia, separated by Lake Kariba, the world's largest man-made lake by volume.  The first part of the drive heads east alongside the Hwange National Park. The rest of the drive takes you north into Binga District, with endless skies and beautiful savanna grasslands.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160607_homestead.jpg" alt="Homestead">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160607_homestead.jpg" alt="Homestead">
 <p class="caption">A Tonga homestead in the savanna. CC-BY American Red Cross.</p>
 </figure>
 
@@ -42,7 +42,7 @@ Prior to the start of the workshop, I joined representatives from the ZimCross H
 At the the training center, I met the 12 volunteers who would be taking part in the workshop and assisting with the data collection. The volunteers were from Binga District, with a majority of them being from Saba Ward, so that their local knowledge of the area and people could assist in the planning and implementation of the mapping. We spent the first part of the day having conversations and discussing important features in the communities. One way we do this is by having the volunteers mark up an OpenStreetMap basemap that we bring with us. Each group of volunteers enjoyed speaking about their communities and what was important to them. On these maps, they drew water sources, markets, paths, and homes of their friends and families.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160607_mapping.jpg" alt="Mapping Exercise">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160607_mapping.jpg" alt="Mapping Exercise">
 <p class="caption">ZimCross staff and volunteers highlighting important points in their community. CC-BY American Red Cross.</p>
 </figure>
 
@@ -53,7 +53,7 @@ With the Missing Maps project, we interact with a broad spectrum of volunteers: 
 The second day, we spend the morning recapping what we learned the previous day, and in the afternoon, went to the community of Siamwinde, which is outside of Saba Ward, but there are many of the similar interventions from the BRACES Project, such as latrines and cookstoves. After the data collection, we regrouped and discussed any obstacles faced in the field.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160607_toLatrine.jpg" alt="Headed to Latrine">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160607_toLatrine.jpg" alt="Headed to Latrine">
 <p class="caption">Mapping a latrine in Siamwinde, built as part of the BRACES project. CC-BY American Red Cross.</p>
 </figure>
 
@@ -62,7 +62,7 @@ The second day, we spend the morning recapping what we learned the previous day,
 Days 3 and 4 started at sunrise, as we began the hour-long drive to Saba Ward. We gave three groups a Garmin GPSMAP 64 device, which would be used to map the pipeline. The other groups were divided throughout the remainder of the area, with ZimCross staff acting as Field Team Leaders. I floated and was able to check on each group's progress and troubleshoot any phone/GPS issues. It was hot. Temperatures reached into the 90s by mid-morning (and this was winter) but whenever we met with a volunteer group, we were greeted with the biggest smiles. On day 4, we had one group of volunteers, along with a field team leader, walk over 20km to reach the community of Kenjobo, where one of the volunteers was from. It was faster for these volunteers to walk the 20km than to drive the 140km to a closer approach. The dedication of the ZimCross volunteers remains an inspiration to me.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160607_scrum.jpg" alt="Group Scrum">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160607_scrum.jpg" alt="Group Scrum">
 <p class="caption">ZimCross staff and volunteers discussing the workplans for the day. CC-BY American Red Cross.</p>
 </figure>
 
@@ -73,7 +73,7 @@ While we met with one group, to determine the best location to have them walk to
 After the second day of data collection, I submitted the data to our OpenMapKit server, and started looking at it and cleaning it up. Over 350 points were collected, including 161 cook stoves, 131 latrines, 32 taps, 5 storage tanks, 9 boreholes, in addition to the 24 km of pipeline was mapped. All of these locations have been added to OpenStreetMap, and are available for anyone to use. The Zimbabwe Red Cross Society can now visualize the impact they are having in the communities in which they serve. With the volunteers, we walked through the process of cleaning the data, and uploading it to OpenStreetMap. The most memorable moment of this trip for me, was showing the volunteers on our final day, the data they collected, on a map. Smiles stretched from ear-to-ear. One volunteer said, "I have never been able to see my community like this before, I can now go and show my community the great things that the Red Cross has brought to us." This is the benefit of an open platform. OpenStreetMap and the Missing Maps project have enabled these volunteers, the same volunteers who helped dig the trench last year for the new pipeline, see the direct impacts in their community.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160607_map.jpg" alt="Data Map">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160607_map.jpg" alt="Data Map">
 <p class="caption">Data collected by ZimCross Volunteers. All data has been added to OpenStreetMap Map Data: OpenStreetMap Contributors.</p>
 </figure>
 
@@ -82,7 +82,7 @@ After the second day of data collection, I submitted the data to our OpenMapKit 
 Lake Kariba has one of the highest densities of crocodiles and hippopotamuses in the world. These types of signs were common:
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160607_signs.jpg" alt="Warning Signs">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160607_signs.jpg" alt="Warning Signs">
 <p class="caption">Warning signs in Binga. CC-BY American Red Cross.</p>
 </figure>
 
@@ -91,20 +91,20 @@ It was incredible to look out over the lake in the evening as the sun was settin
 All throughout the week I spent in Binga, I saw piles of "ele-poo" along the road, but we just kept missing them. After a quick trip to Victoria Falls before my flight, lo and behold, we saw six elephants heading to get a drink of water – quite the traffic jam on the commute to the airport.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160607_elephant.jpg" alt="Elephant">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160607_elephant.jpg" alt="Elephant">
 <p class="caption">Close encounter with some elephants on the way back to the airport. CC-BY American Red Cross.</p>
 </figure>
 
 Baboons also enjoyed darting in front of traffic. Check out this picture we caught with our [Mapillary Camera](http://www.mapillary.com/map/search/-18.14510808710267/26.603609478092864/9) of a baboon running right in front of us.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160607_baboon.JPG" alt="Baboon">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160607_baboon.JPG" alt="Baboon">
 <p class="caption">A baboon runs in front of our car heading back to Victoria Falls. CC-BY American Red Cross.</p>
 </figure>
 
 Everywhere I've gone with the American Red Cross has been rewarding in its own way. I enjoy working alongside volunteers throughout the world all dedicated to the Red Cross Movement. I was told that in Zimbabwe if someone has a long journey ahead of them, they'll say they are "traveling to Binga". My trip to Binga, while literal, also took me further from home than I've ever been, but was welcomed by so many great volunteers. The Zimbabwe Red Cross Society's volunteers put themselves on the map, and now have the ability to continue doing so.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160607_group.jpg" alt="Group Picture">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160607_group.jpg" alt="Group Picture">
 <p class="caption">Team of ZimCross staff and volunteers. CC-BY American Red Cross.</p>
 </figure>

--- a/2016-06-28-border-country.md
+++ b/2016-06-28-border-country.md
@@ -3,7 +3,7 @@ layout: post
 title: Without Frontiers in Border Country
 postID: without-frontiers
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160628_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160628_banner.jpg
 date: 2016-06-28
 author: Rupert Allan
 excerpt: Sierra Leone Red Cross volunteers are methodically surveying the missing, misnamed, and unrepresented villages of the border region for the Post-Ebola Community Rebuild project. Spearheaded by Missing Maps, it is a fundamental vulnerability assessment of at-risk areas where epidemics and natural disasters can run and spread for weeks un-checked.
@@ -20,28 +20,28 @@ We don't have time. We have to turn back, but if I've got it wrong, there will b
 Kondewakoro is a border village in the far reaches of the Toli Chiefdom of Kono District, Sierra Leone. AKA 'Diamond Country'. On [OpenStreetMap](http://www.openstreetmap.org/#map=7/8.500/-11.541), the only map of this corner of Africa, the road we are on shows as a decently defined yellow line. In England or Wales, it would be a tarmacced trunk road. We are not on tarmac, though. No, these roads, for all their ancient status, are not even really roads, more determined cuts through the bush.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160628_guinea-highway.jpg" alt="Guinea highway">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160628_guinea-highway.jpg" alt="Guinea highway">
 <p class="caption">'The Guinea Highway'. CC-BY Rupert Allan.</p>
 </figure>
 
 I am attempting to track down Sulaiman Charles, the teacher, but am wondering if this is a wild goose-chase all these hours down this bush track in 'Zulu One-Five', our trusty and iconic MSF Landcruiser. Getting battered about hour after hour, rock after rock, river after river. I have learned to trust Ahmet's driving through these unlikely passages. I made an arrangement with Sulaiman to meet on the road to Kondewakoro over a broken phone conversation more than six hours ago. Sulaiman is an energetic spokesperson, a brilliant teacher with presence and vigour. He is one of my Field Team Leaders, in charge of six Sierra Leone Red Cross volunteers who are methodically surveying the missing, misnamed, and unrepresented villages of the border region for the Post-Ebola Community Rebuild project. Spearheaded by Missing Maps (American Red Cross, MSF, Humanitarian OpenStreetMap Team), it is a fundamental vulnerability assessment of at-risk areas where epidemics and natural disasters can run and spread for weeks un-checked.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160628_sulaiman-chiefdoms.jpg" alt="Working the map">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160628_sulaiman-chiefdoms.jpg" alt="Working the map">
 <p class="caption">Working the map (Sulaiman's Chiefdoms). CC-BY Rupert Allan.</p>
 </figure>
 
 We are here to correct the map, or more accurately, to leave the capacity for the inhabitants of Toli to map themselves. We have trained four other team leaders like Sulaiman – the best and brightest that the national border regions have to offer. We have also been training a cohort of supervised volunteers. Trained them in the classroom. But this is the bush. And now it is a question of finding them, as they map what can't be mapped, and we, hampered by the very resistance factors which have prohibited this mapping for so long, are trying to support.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160628_health-centres.jpg" alt="Mapping a health centre">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160628_health-centres.jpg" alt="Mapping a health centre">
 <p class="caption">Volunteers putting a health centre on the map in Koinadugu District, aka 'The Land of the Powerful Mixture'. CC-BY Rupert Allan.</p>
 </figure>
 
 In another chiefdom in the North I came across a border crossing into Guinea made of rickety palm-wood bars. I was reluctant to 'snap' the sleepy photogenic border-guard in his vest, standing under the words 'Immigration' pencilled on the flaking cement above the 'office' doorway. Things can escalate easily here. There are strict security protocols, and the sensitivity of this 'porous' borderland domain dictates that we follow strict MSF radio-contact schedules. We are in two-hourly contact with the radio-room in Freetown. A day away. Now, I would like to meet Sulaiman at the border, but we have a lot of ground to cover, and a six o'clock travel curfew to observe. This is no-man's land. I am aware of the need for caution.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160628_young-biker.jpg" alt="motorcycle">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160628_young-biker.jpg" alt="motorcycle">
 <p class="caption">On the way to Kondewakoro. CC-BY Rupert Allan.</p>
 </figure>
 
@@ -56,42 +56,42 @@ Imperceptibly he nods, and says something. Ahmet interprets a Krio mutter and th
 '...and is there another road?' No. No other road. This is the only way to Kondewakoro. We get back into the Landcruiser which flops down the track between the boulders. It doesn't feel possible yet, but we have somewhere to stay tonight. One hour to go until curfew. No turning back, but now it is certain that we will find him.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160628_loaded-motorbike.jpg" alt="How to load a motorbike">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160628_loaded-motorbike.jpg" alt="How to load a motorbike">
 <p class="caption">How to load a motorbike. CC-BY Rupert Allan.</p>
 </figure>
 
 And ten minutes later we literally almost run-over Sulaiman on his motorbike. Komba, the isolated volunteer tasked with this spur of the project is interviewing the Village Chief in a clearing. It turns out Komba is a star surveyor, with an amazing grasp of the job in hand. It is difficult to deliver the detailed survey, with its questions about water availability, its carefully crafted cross-referencing of sanitation and disease questions, road conditions and Healthcare access. But it has been worth coming to see how it is done properly.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160628_charging-phones.jpg" alt="Wiring motorbikes to charge phones">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160628_charging-phones.jpg" alt="Wiring motorbikes to charge phones">
 <p class="caption">Missing Maps field consultation. Wiring motorbikes to charge phones. CC-BY Rupert Allan.</p>
 </figure>
 
 There has been a 'Loma' Market here today. It has been a hive of activity. As I look around this village, seemingly thriving in its own right, I can't help wondering how on earth some of this actual concrete came to be here, given the impossible nature of the only road in. It will be a long time before these villages have convincing vehicular access, despite the fact that they are located on this footpath they call 'The Guinea Highway'. This track, for better or worse, protects this village in some way, from invasion, but at the same time makes it vulnerable to a changing world around it.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160628_broken-crossing.jpg" alt="Ooops">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160628_broken-crossing.jpg" alt="Ooops">
 <p class="caption">Ooops. CC-BY Rupert Allan.</p>
 </figure>
 
 As we photograph wells and water sources, with different surveys, the bigger picture which emerges is the sparsity of consistent water, and the dangerous propensity of water-contamination at source. Villages look well-ordered sometimes, but once surveys start to show exactly how many people actually use the water-sources, how often they dry-up, and how close to latrines (another resource we survey) they can be, the data starts to tell another story; desperate need and hard-boiled living in this disowned and precarious border area. I later geo-photograph two pumps in Kpetema – an 'India MkII' and a 'Bush' pump. Neither of them dries up in dry season, which makes Kpetema regionally important. We have come across several villages where women are washing in the ford we are crossing, and children carry water from the same river up the hill for drinking.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160628_river-water.jpg" alt="Ooops">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160628_river-water.jpg" alt="Ooops">
 <p class="caption">River ford. CC-BY Rupert Allan.</p>
 </figure>
 
 These communities are susceptible to so much disease from so many quarters. When disaster occurs, their location needs to be traced. Whatever way the locals want it, it needs a name – particularly when some desperate community mobilisation team in the capital receive a dying patient and are trying to pinpoint the place they came from. Local names are important. Geo-tags are critical. Terror spreads as fast as the epidemic itself in these communities, and there are many instances of death resulting from panic as well as actual disease. The enemy is the unknown.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160628_well.jpg" alt="Ooops">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160628_well.jpg" alt="Ooops">
 <p class="caption">CC-BY Rupert Allan.</p>
 </figure>
 
 It is the end of the day now, and gaving gathered for council on wooden benches, and sat through typically long-winded introductions with Mami-Queen and Chief, solemn nods were closely followed by furious handshakes (post-Ebola protocol thankfully now permits careful physical contact) and gentle curiosity. Part of the meeting ritual involved the explanation of the corrected name of this village. It moved because of forest fires decades ago, so what I have on my OpenStreetMap, 'Kekeya', compiled from old military or colonial data, needs adjusting and renaming. The Chief and the Youth Leader peered curiously over my shoulder as I renamed the village on my phone screen. Approving grunts at me spelling-out the proper village name give way to open-faced enthusiasm and laughing recognition of Chiefdoms and Sub-Chiefdoms so carefully researched by our team and so now available on our own [OpenMapKit](http://openmapkit.org/) app.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160628_osm-android.jpg" alt="Ooops">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160628_osm-android.jpg" alt="Ooops">
 <p class="caption">Screenshot with my GPS tracks from [OsmAnd](http://osmand.net/) – the everyman SatNav.</p>
 </figure>
 
@@ -100,14 +100,14 @@ It has already been established that I am the evangelist in my team, and the peo
 And now the dim shape of the Landcruiser looms in the gloaming as I look out into the village from the out-patient's waiting bench. Night is falling. Ahmet, my driver, is preparing the Landcruiser for the night. The sound of crickets and other forest insects almost drowns out the quiet African consonants being murmured over food amongst the houses across the track. The cool crescent of the moon is a welcome sight beckoning the forest woodsmoke to rise and meet it. In another part of Africa it has celestial pageantry which I know. I wonder, through the dusk, how they read the stars here. The old navigation envisaged by the new.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160628_night-falling.jpg" alt="Dusk">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160628_night-falling.jpg" alt="Dusk">
 <p class="caption">Night falls. CC-BY Rupert Allan.</p>
 </figure>
 
 I shall sleep in the mud-built health outpost tonight. The nurse cooks under the palm kitchen roof, and I am sitting, fresh-washed and waiting for what will turn out to be a huge bowl of sweet rice and yoghurt. The pot is simmering on the fire already, gently steaming. I have done 'Community Entry'. There are rules with village contact here, and society dictates that strangers initially approach the Chief. The performance of this tradition goes back in time, reflecting how outsiders have always been received into these isolated communities.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160628_road-signs.jpg" alt="Dusk">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160628_road-signs.jpg" alt="Dusk">
 <p class="caption">Signage. CC-BY Rupert Allan.</p>
 </figure>
 

--- a/2016-07-06-atomfeed.md
+++ b/2016-07-06-atomfeed.md
@@ -3,7 +3,7 @@ layout: post
 title: Atom Feed
 postID: atom feed
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160706_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160706_banner.jpg
 date: 2016-07-06
 author: Dale Kunce
 excerpt: As the blog expands we added an atom feed so you can subscribe and get the latest updates on Missing Maps.

--- a/2016-07-11-trends-of-transformation.md
+++ b/2016-07-11-trends-of-transformation.md
@@ -3,7 +3,7 @@ layout: post
 title: Trends of Transformation by Mapping in West Africa
 postID: trends-of-transformation
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160711_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160711_banner.jpg
 date: 2016-07-11
 author: David Luswata
 excerpt: Our work in the recent couple of months has been to map communities in a 15 kilometre buffer of the borders of Sierra Leone, Liberia and Guinea – this was the region most affected by Ebola Virus Disease. This has been achieved over and above our expectation. Each of these countries has had its challenges in mapping the communities, but the successes supersede the somewhat expected challenges.
@@ -16,35 +16,35 @@ lang: en
 Sierra Leone. Liberia. Guinea. Driving from one capital to another, from one end of the border to the other, I cannot help but notice that the last 27 years have been particularly difficult for life in these three greatly endowed countries. They form what is known as the Mano River Union (MRU). In 1989, the First Liberian Civil broke out, hundreds of thousands of lives were lost. Not long after this war started, in 1991 the Sierra Leone Civil war broke out. In 1997, it was thought that life had come back to normal in Liberia, but just two years later, backed by neighboring Guinea, the Second Liberia Civil war broke out. The impact and effects of each of these wars spilled so easily over to each one of its neighboring Mano River Union comrades. War drums have since 2003 been terminated, with a sincere living hope, that they will never sound again, ever. Moving through the border regions of the great countries, I easily notice the pain and impact the times of war have caused to the lives in these three countries. You so easily see houses, very well constructed, abandoned in the bushes no longer habited. Where are the inhabitants... do not ask that question.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160711_abandoned-house.jpg" alt="Abandoned house">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160711_abandoned-house.jpg" alt="Abandoned house">
 <p class="caption">Abandoned house. CC-BY David Luswata.</p>
 </figure>
 
 Greatly endowed with the Atlantic Ocean, very many rivers, thick forests and great diamond and other mineral deposits, “Life has since then been on an upward scale. Every one going about their business, building a nation and a region again,” narrates my driver as we cruise through the potholed roads of Macenta Prefecture in Guinea on our way to Liberia. “It was so until something strange came among us. We had fought many battles, but this was to be different. We were fighting an enemy we could not see. We didn’t know where he came from, we had never heard or seen something like that.” he continues.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160711_osmand.jpg" alt="Navigating">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160711_osmand.jpg" alt="Navigating">
 <p class="caption">Navigation using [OsmAnd](http://osmand.net/). CC-BY David Luswata.</p>
 </figure>
 
 It is called the Ebola Virus Disease (EVD). It’s one of the strangest disease outbreaks of recent history. As it were, a single case can turn into a full brown outbreak with in just days, if unknown or left unchecked. In 2014, in a small village in Guinea, it was thought to be a normal death, within weeks, it spread like a spirited fire. Spread across to Liberia and Sierra Leone and many other places. Life was extremely unbearable. As weeks went by, there was an increasing somber feeling sweeping across the region, people were dying. This outbreak was another great threat to the region. In January, March and June 2016, WHO declared the end of the EVD outbreak in Liberia, Sierra Leone and Guinea respectively. However, individuals departing and entering any of these countries are required to take temperature readings. This is still happening as well at all border crossings in the region.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160711_taking-temperature.jpg" alt="Safety precautions">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160711_taking-temperature.jpg" alt="Safety precautions">
 <p class="caption">Getting a temperature reading at a border crossing. CC-BY David Luswata.</p>
 </figure>
 
 Our work in the recent couple of months has been to map communities in a 15Km buffer of the three countries' borders – this was the region most affected by EVD. This has been achieved over and above our expectation. Each of these countries has had its challenges in mapping the communities, but the successes supersede the somewhat expected challenges. The border area forms an interior part of the three countries, with thick forests in most parts, many rivers and several types of wild animals. Roads are in indeed poorer conditions in these border areas, telecommunication signals unavailable in a vast part of the region and socio-economic facilities and services far-fetched in majority of the places. The power of volunteerism still reaches even to the very remotes village. Equipped with a mobile phone, [OMK](http://openmapkit.org/), [ODK](https://opendatakit.org/), [OsmAnd](http://osmand.net/) and [OpenSignal](http://opensignal.com/), we sent volunteers to as many communities as people live in. Some places, a motorbike can’t reach, you have to walk for some hours to get to a community, or in some, grab a boat.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160711_volunteer-travel.jpg" alt="Volunteer travel">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160711_volunteer-travel.jpg" alt="Volunteer travel">
 <p class="caption">Travel by motorbike and foot may be the only way to reach some communities. CC-BY David Luswata.</p>
 </figure>
 
 With some volunteers not owning a smart phone, tests were done and the best volunteers were selected. With the excitement of the new tools to use, volunteers spread out to the entire region, first in Liberia, then Guinea and then Sierra Leone. Having lost several relatives and community members in the epidemic, the stories of these energetic and passionate volunteers drive me to map one more village, and want to teach whoever I can reach how to map. Many of them participated in contact tracing and community sensitization during the pandemic. Building on these basic tech skills, we are building a community that will continue to map these countries, putting the world’s most vulnerable people on the map.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160711_volunteer-mapping.jpg" alt="Volunteer mapping">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160711_volunteer-mapping.jpg" alt="Volunteer mapping">
 <p class="caption">A volunteer gathering data from community members. CC-BY David Luswata.</p>
 </figure>
 

--- a/2016-07-14-mapswipe.md
+++ b/2016-07-14-mapswipe.md
@@ -3,7 +3,7 @@ layout: post
 title: MapSwipe
 postID: mapswipe
 category: [MapSwipe]
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160714_mapswipe.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160714_mapswipe.jpg
 date: 2016-07-14
 author: Pete Masters
 excerpt: MapSwipe enables anyone with a smartphone to contribute to the mapping of these vulnerable communities. Download the app, choose a mission, read the instructions and get started!

--- a/2016-07-18-mapswipetutorial.md
+++ b/2016-07-18-mapswipetutorial.md
@@ -3,7 +3,7 @@ layout: post
 title: MapSwipe Tutorial
 postID: mapswipe-tutorial
 category: [MapSwipe]
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160714_mapswipe.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160714_mapswipe.jpg
 date: 2016-07-18
 author: Pete Masters
 excerpt: MapSwipe relies on users being able to interpret what they see in the satellite imagery provided. This tutorial gives some guidance on how best to do that.

--- a/2016-07-22-mapswipe-progress-and-feedback.md
+++ b/2016-07-22-mapswipe-progress-and-feedback.md
@@ -3,7 +3,7 @@
  title: MapSwipe... Feeding back on your feedback
  postID: mapswipe-feedback
  category: [MapSwipe]
- banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160714_mapswipe.jpg
+ banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160714_mapswipe.jpg
  date: 2016-07-22
  author: Pete Masters
  excerpt: We have had an amazing response to MapSwipe in terms of the mapping you have done, but also your feedback and bug reports. We are listening! Find out here what we are doing to address the most common issues.

--- a/2016-08-01-mapswipe-update.md
+++ b/2016-08-01-mapswipe-update.md
@@ -3,7 +3,7 @@ layout: post
 title:  What's new with MapSwipe
 postID: mapswipe-update
 category: [MapSwipe]
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160714_mapswipe.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160714_mapswipe.jpg
 date: 2016-08-01
 author: Pete Masters
 excerpt: Following the excellent feedback so many of you sent us, our team has been hard at work to get the next update out. Get the details, here!

--- a/2016-08-02-mapping-every-detail.md
+++ b/2016-08-02-mapping-every-detail.md
@@ -3,7 +3,7 @@ layout: post
 title:  Mapping Every Detail
 postID: mapping-every-detail
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160802_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160802_banner.jpg
 date: 2016-08-02
 author: David Luswata
 excerpt: After initially sending volunteers to record all the population centres in the border regions, we then selected some emerging cities in Liberia, Guinea and Sierra Leone to map in their entirety. Volunteers spend hours and days moving from one corner of the city to the other mapping every mappable entity, capturing every detail.
@@ -17,7 +17,7 @@ lang: en
 
 The term ‘city’ often elicits an image of towering metropolises. However, this image is more consistent with cities found in already developed nations. For the many towns and evolving communities in still developing countries, we have a different classification: ‘emerging cities’. These emerging cities are at the center of development, showing rapid population growth as an increasing number of people leave villages to pursue opportunity in these cities. In these epicenters of commerce, a wide range of commodities can be found in markets as people innovate and continue to improve their livelihoods. In all of this, we see promise as humanity advances and lives and communities continue to improve.    
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160802_city.jpg" alt="Emerging cities, emerging promise.">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160802_city.jpg" alt="Emerging cities, emerging promise.">
 <p class="caption">Emerging cities, emerging promise. CC-BY David Luswata.</p>
 </figure>
 
@@ -39,7 +39,7 @@ Located in the south of Guinea, the city of Gueckedou is one of the major gatewa
 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160802_market.jpg" alt="Market day in Gueckedou">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160802_market.jpg" alt="Market day in Gueckedou">
 <p class="caption">Market day in Gueckedou. CC-BY David Luswata.</p>
 </figure>
 
@@ -54,7 +54,7 @@ He continues, “If any one became sick in that time, your family would desert y
 Celestine Kamano is one of our Field Team Leaders in Guinea. Despite being a recent graduate in Linguistic Science, Celestine has been using his brother’s laptop to learn to map whenever he is not in the field collecting data. When our work started he had not found a job yet. Hte was successful in applying for and joining our team. Now he is thinking of changing his career to better contribute to his country through mapping. “I am saving up to buy a laptop so that I can always be able to map my country. This project has opened my eyes. There are a lot of things not mapped here, and now I know that I can make a contribution to my country by mapping. Through going to very many communities within the 15 kilometre radius, I have seen how life is from community to community. This has given me a lot of reflection on what my country and communities are. I am already thinking of how I can help; I will start with mapping.”
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160802_celestine.jpg" alt="Celestine mapping">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160802_celestine.jpg" alt="Celestine mapping">
 <p class="caption">Celestine mapping. CC-BY David Luswata.</p>
 </figure>
 
@@ -65,7 +65,7 @@ In one town, after explaining why we are mapping and how useful it is, a lady ca
 In another community, while mapping was going on, we took time to view submissions to the server to show the volunteers real time results from their efforts. The volunteers were with a local leader from this community, and as we started viewing the uploads and the mapped buildings, a group of young men came as well to steal a look. Judging by their enthusiastic looks at our work, those young men are potential mappers.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160802_server.jpg" alt="Viewing submissions">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160802_server.jpg" alt="Viewing submissions">
 <p class="caption">Viewing submissions to the server in the field. CC-BY David Luswata.</p>
 </figure>
 

--- a/2016-09-13-guinea-women.md
+++ b/2016-09-13-guinea-women.md
@@ -3,7 +3,7 @@ layout: post
 title: Putting Guinea’s reproductive health issues on the map
 postID: putting-guineas-reproductive-health-issues-on-the-map
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160916_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160916_banner.jpg
 date: 2016-09-16
 author: Chris Glithero, Paul Knight, Kat Hicks
 excerpt: "The Danish, Swiss and British Red Cross are currently working together to support the Guinea Red Cross in developing integrated, high quality programmes, and the Reproductive Health and Rights Programme is one of these. It aims to improve knowledge and access to reproductive health and rights in the Moyenne Guinée region of the country."
@@ -42,7 +42,7 @@ It also found that, “poor women in remote areas are the least likely to receiv
 To tackle these issues, the Guinea Red Cross’ Reproductive Health and Rights Programme, aims in part to improve access to emergency medical care for women experiencing childbirth complications. It also aims to shift practices and cultural viewpoints regarding FGM, and to improve knowledge, rights and access to reproductive health in key areas of the country.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160916_village.jpg" alt="village">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160916_village.jpg" alt="village">
 <p class="caption">Community in Labé region. CC-BY-NC-ND British Red Cross, Danish Red Cross and Swiss Red Cross</p>
 </figure>
 
@@ -74,13 +74,13 @@ Once the map features added by remote Missing Maps volunteers have been validate
 The completed maps will then be available for project staff and volunteers to use throughout the programme, and will provide a vital geographic data source with which to visualise the results from the baseline survey.  More importantly, they will play an integral role in implementing systems which will help to ensure that pregnant women experiencing birth complications get the immediate medical attention they need.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160916_dwelling.jpg" alt="dwelling" style="width: 400px;">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160916_dwelling.jpg" alt="dwelling" style="width: 400px;">
 <p class="caption">Baseline surveying. CC-BY-NC-ND British Red Cross, Danish Red Cross and Swiss Red Cross</p>
 </figure>
 
 Without accurate maps – which can guide to a destination, highlight needs, reveal patterns and track developments - the work of aid and development organisations to save and enhance lives can be made even more difficult. Through the efforts of HOT and the Missing Maps community, large swathes of the world which were previously in shadow have been revealed, and the positive impacts of this are only just beginning to be realised.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20160916_team.jpg" alt="team">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20160916_team.jpg" alt="team">
 <p class="caption">The mobile data collection team. CC-BY-NC-ND British Red Cross, Danish Red Cross and Swiss Red Cross</p>
 </figure>

--- a/2016-10-07-osm-geoweek.md
+++ b/2016-10-07-osm-geoweek.md
@@ -3,7 +3,7 @@ layout: post
 title: "OSM Geography Awareness Week: 13-19 November"
 postID: osm-geoweek
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20161007_banner.png
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20161007_banner.png
 date: 2016-10-07
 author: Emily Eros
 excerpt: "Missing Maps members are gearing up for OSM Geography Awareness Week this Novmber, hoping to support over 100 mapathons around the world!"
@@ -32,6 +32,6 @@ This week presents a great opportunity for students, coworkers, or members of a 
 If your organization is interested in participating, the Missing Maps network and our colleagues can provide you with the information and materials needed to host a successful mapathon. If you’re located in the USA, then we can even send you a box of stickers and other swag as a care package for your event! If you'd like to host an event, [sign up here](https://docs.google.com/forms/d/1SG9DW7ZyEC9Vf78RbApUfBYAQPSIReyxbupGJPCqjtw/viewform?edit_requested=true).
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20161007_swag.png" alt="Stickers galore">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20161007_swag.png" alt="Stickers galore">
 <p class="caption">Want some stylish mapathon accessories for your event? Sign up on the website and we'll mail you a box of stickers and more! (Apologies to those outside the USA, but we can't ship internationally)</p>
 </figure>

--- a/2016-11-01-partnerpages.md
+++ b/2016-11-01-partnerpages.md
@@ -3,7 +3,7 @@ layout: post
 title: "Partner Pages"
 postID: partner-pages
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/partner-pages.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/partner-pages.jpg
 date: 2016-11-01
 author: Dale Kunce
 excerpt: "The next step in data analytics is coming to Missing Maps. Using the infrastructure we continue to build out on the Missing Maps leaderboards and osm-stats-api we are very happy to announce the creation of partner pages. Partner pages can be any sort of partner from some of Missing Maps corporate partners such as JP Morgan Chase to local groups such as Maptime."
@@ -27,13 +27,13 @@ If you would like to have your own partner page included into the main Missing M
 When we launched the Missing Maps leaderboards we only tracked hashtags if #missingmaps was included with the commit. We did this to make sure our little leaderboard workers could keep up. Long story, we worked out a lot of bugs and we are now turning off the restriction of including the #missingmaps hashtag to track your project. All hashtags regardless of what they are now being tracked and can be searched and analyzed via the [leaderboards](http://missingmaps.org/leaderboards). Be sure to include your custom hashtag in your changeset comment when saving.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/new_hashtag.gif" alt="new hashtag">
+<img src="https://github.com/MissingMaps/img/blob/main/images/new_hashtag.gif" alt="new hashtag">
 <p class="caption">Adding a custom hashtag to your changeset comment. CC-BY American Red Cross.</p>
 </figure>
 
 To view the custom leaderboard go to the [leaderboard page](http://missingmaps.org/leaderboards) and click on "Add Competitor" to to see the leaderboard for your hashtag or event. Add more than one competitor to see how you stack up [against another group](http://www.missingmaps.org/leaderboards/#/redcross,rodekruis).
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/add_hashtag.gif" alt="add hashtag">
+<img src="https://github.com/MissingMaps/img/blob/main/images/add_hashtag.gif" alt="add hashtag">
 <p class="caption">Adding a custom hashtag to the leaderboard. CC-BY American Red Cross.</p>
 </figure>

--- a/2016-11-16-facebook.md
+++ b/2016-11-16-facebook.md
@@ -3,7 +3,7 @@ layout: post
 title: "Facebook Collaboration"
 postID: facebook
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/facebook-banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/facebook-banner.jpg
 date: 2016-11-16
 author: Dale Kunce
 excerpt: "In our humanitarian mission we are data omnivores, within licensing restrictions of course, constantly looking for datasets that can aid our mission and the larger mapping community. Collaborating with Facebook is an obvious step for us to take. Using the data created by Facebook volunteers will waste less time checking out a task to find an area with nothing to map. "
@@ -20,7 +20,7 @@ In our humanitarian mission we are data omnivores, within licensing restrictions
 The data for Malawi was already used during OSMGeoWeek to help map over 1 million people in Blantyre, Malawi. And will help the Missing Maps partners better focus are mapping in the next few months as we strive to completely remotely map Malawi to support the many humanitarian projects there.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/blantyre_buildings.gif" alt="new hashtag">
+<img src="https://github.com/MissingMaps/img/blob/main/images/blantyre_buildings.gif" alt="new hashtag">
 <p class="caption">Mapping by volunteers in Blantyre, Malawi during OSM GeoWeek 2016</p>
 </figure>
 

--- a/2016-11-25-osmgeoweek-thankyou.md
+++ b/2016-11-25-osmgeoweek-thankyou.md
@@ -3,7 +3,7 @@ layout: post
 title: "OSM GeoWeek Thank You!"
 postID: osmgeoweek-thankyou
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/geoweek_2016_ucla.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/geoweek_2016_ucla.jpg
 date: 2016-11-28
 author: Rachel Levine
 excerpt: "Thank you for your incredible efforts organizing this year's OSM GeoWeek! In total 140 public and 150 private events took place in 42 countries.  We made 1 million edits and added 861,865 buildings and 145,030 km of roads to OSM. Thanks to your hard work, almost 4,000 new mappers joined the OSM community! "
@@ -31,6 +31,6 @@ It's a great idea to follow-up with your participants (if you haven't already). 
 Again, from all of us on the OSM GeoWeek organizing team, thank you so much for your planning, mapping, and continued support!
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20161128_geoweek.jpg" alt="GeoWeek">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20161128_geoweek.jpg" alt="GeoWeek">
 <p class="caption">6th grade students participating in a geography workshop in India. Photo Credit: <a href="http://www.openstreetmap.org/user/upendrakarukonda/diary/39889" target="_blank">upendrakarukonda.</a></p>
 </figure>

--- a/2017-01-06-opensignal-data.md
+++ b/2017-01-06-opensignal-data.md
@@ -3,7 +3,7 @@ layout: post
 title: Mapping cell phone signals
 postID: opensignal
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/signal_strength.png
+banner: https://github.com/MissingMaps/img/blob/main/images/signal_strength.png
 date: 2017-01-06
 author: Emily Eros
 excerpt: This past spring/summer, over 100 Red Cross volunteers conducted field mapping in the border regions of Guinea, Liberia, and Sierra Leone. In addition to the actual mapping, we also set the volunteers' phones to record their GPS tracks each day, and we set their phones to automatically collect cell signal strength data using OpenSignal, an app which crowdsources this information. We haven't come across much about working with OpenSignal data, so this post documents our workflow for using the data, the challenges we had, and our results.
@@ -31,7 +31,7 @@ We loaded OpenSignal onto all of the phones before the fieldwork began, then dow
 OpenSignal generated three types of CSV files: wifi, speedtests, and cell signals:
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/file_types.png" alt="File types">
+<img src="https://github.com/MissingMaps/img/blob/main/images/file_types.png" alt="File types">
 <p class="caption">CC-BY American Red Cross.</p>
 </figure>
 
@@ -96,7 +96,7 @@ I loaded the CSV file into GIS and converted it into an equal-area projection (t
 Again, the data look very sparse compared to the amount of volunteers and time spent in the field. The image below shows the OpenSignal data overlaid on GPX tracks collected by volunteers (shown in grey) for the West African region. The OpenSignal data covers some main highways across the region and some clusters in certain cities, but it's extremely sparse compared to what I was expecting.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/signal_strength.png" alt="Signal strength">
+<img src="https://github.com/MissingMaps/img/blob/main/images/signal_strength.png" alt="Signal strength">
 <p class="caption">CC-BY American Red Cross.</p>
 </figure>
 
@@ -105,7 +105,7 @@ The settings on the OpenSignal app explain, "Data is collected when the app is o
 That's not what I see in the West Africa data. The snippet below contains data from a few different files. In each of these files, a phone collects data briefly when set up in late March... then nothing until a month later, at the end of April. When the phones are logging data, they are doing so at the expected rate of about 10x per hour... it's just that there are huge gaps between the readings.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/timestamps.png" alt="time stamps">
+<img src="https://github.com/MissingMaps/img/blob/main/images/timestamps.png" alt="time stamps">
 <p class="caption">CC-BY American Red Cross.</p>
 </figure>
 
@@ -118,7 +118,7 @@ Next steps for the data involve turning the OpenSignal data into a raster (ie pi
 To do this, we zoomed in to an area in the Eastern Province of Sierra Leone with a high density of signal recordings. We took the RSSI values for these recordings and then performed [kriging](http://www.qgistutorials.com/en/docs/interpolating_point_data.html) using the inverse distance weighting method. What this means: we have a set of points and we want to fill in the gaps between them to predict what the cell signal strength will be in other areas nearby. When doing this, we set a distance limit on how far away the kriging will examine. Too small, and we won't learn that much. Too large, and the results won't be very accurate. Even with an appropriate distance limit, predictions won't be perfect because we aren't factoring in topography or other things that might affect signal strength. But this is still enough to help understand the gaps in the data for a local area. The output from the kriging is a grid of cells, each of which has a predicted RSSI value. This helps us to understand connectivity "hotspots" in the local area.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/kriging.png" alt="IDW kriging surface. Cell size is set to 10m">
+<img src="https://github.com/MissingMaps/img/blob/main/images/kriging.png" alt="IDW kriging surface. Cell size is set to 10m">
 <p class="caption">CC-BY American Red Cross.</p>
 </figure>
 

--- a/2017-01-07-gps-tracks.md
+++ b/2017-01-07-gps-tracks.md
@@ -3,7 +3,7 @@ layout: post
 title: "Roads less traveled... all 72,000 km of them"
 postID: gps-tracks
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/motorbike_road.png
+banner: https://github.com/MissingMaps/img/blob/main/images/motorbike_road.png
 date: 2017-01-07
 author: Emily Eros
 excerpt: "Red Cross volunteers on motorbikes logged 72,000 km of GPS tracks during border mapping in West Africa. We used these data to get under the clouds and add roads to OSM that can't be seen from satellite imagery. These roads connect some of the most remote communities in the region. Here's how we processed the dataset and what we were able to do with it."
@@ -22,8 +22,8 @@ Next, we cleaned up the data. This involved removing any GPX track points with a
 We mapped the data to see the full extent of how much ground the volunteers covered:
 
 <figure>
-<a href="https://arcmaps.s3.amazonaws.com/share/blog-pictures/gpx-tracks-compressed.png">
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/gpx-tracks-compressed.png"></a>
+<a href="https://github.com/MissingMaps/img/blob/main/images/gpx-tracks-compressed.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/gpx-tracks-compressed.png"></a>
 <p class="caption">GPS tracks in West Africa, with snapshot of local area. CC-BY American Red Cross</p>
 </figure>
 
@@ -32,7 +32,7 @@ We mapped the data to see the full extent of how much ground the volunteers cove
 These data aren't just pretty; they're also useful for adding roads to OSM. Several areas in the border regions have really cloudy satellite imagery and we wouldn't be able to trace the roads if it weren't for the GPX data.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/trace_roads.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/trace_roads.png">
 <p class="caption">GPX data lets us get underneath the clouds to add roads to OpenStreetMap (OSM). Track points are shown in fuschia. CC-BY American Red Cross</p>
 </figure>
 

--- a/2017-01-18-two-year-update.md
+++ b/2017-01-18-two-year-update.md
@@ -3,7 +3,7 @@ layout: post
 title: "Two Year Update"
 postID: two-year-update
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/westAfrica-webbanner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/westAfrica-webbanner.jpg
 date: 2017-01-18
 author: Dale Kunce
 excerpt: Since its launch in 2014, Missing Maps has engaged almost 20,000 mappers, helped 430+ public mapathons, put 29 million people on the map, and mapped an area equal to the size of Sweden. We've added many new partners to help try and map the world. Thanks to everyone out there who's been a part of this amazing project!
@@ -66,6 +66,6 @@ It's amazing for us to look back and see how much we've accomplished together as
 ## One Pager
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps_onepage_jan17-USLetter.png" alt="two year update">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps_onepage_jan17-USLetter.png" alt="two year update">
 <p class="caption">Two-Year Update. CC-BY Missing Maps</p>
 </figure>

--- a/2017-01-24-west-africa-mapping-hub-end.md
+++ b/2017-01-24-west-africa-mapping-hub-end.md
@@ -3,7 +3,7 @@ layout: post
 title: "West Africa Project End"
 postID: west-africa-end
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/westAfrica-webbanner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/westAfrica-webbanner.jpg
 date: 2017-01-24
 author: Matthew Gibb, Emily Eros
 excerpt: Wrapping up our largest undertaking since the start of the Missing Maps project was in West Africa. Covering an area the size of Switzerland, volunteers in Liberia, Guinea, and Sierra Leone visited over 7,000 communities in an area that saw the worst of the Ebola crisis in 2014 and 2015.
@@ -18,7 +18,7 @@ lang: en
 2016 was a busy year for the the American Red Cross and the Missing Maps project. Community-led mapping projects took place in [Colombia](http://www.missingmaps.org/blog/2015/03/29/riohacha-colombia/), Ecuador, and [Zimbabwe](http://www.missingmaps.org/blog/2016/06/07/zimbabwe/). Our largest undertaking since the start of the Missing Maps project was in West Africa. Covering an area the size of Switzerland, volunteers in Liberia, Guinea, and Sierra Leone visited over 7,000 communities in an area that experienced the worst of the Ebola crisis in 2014 and 2015. Here's a snapshot of what the volunteers accomplished:
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/westafrica_stats_horizontal.jpg" alt="Quick stats">
+<img src="https://github.com/MissingMaps/img/blob/main/images/westafrica_stats_horizontal.jpg" alt="Quick stats">
 <p class="caption">A few West Africa stats at a glance. CC-BY American Red Cross.</p>
 </figure>
 
@@ -29,15 +29,15 @@ We started the West Africa project because information gaps in available data ma
 The mapping project involved five processes, which consisted of tech development, a mapping hub, a rapid assessment survey, detailed community mapping, and community engagement.
 
 <figure>
-<a href="https://arcmaps.s3.amazonaws.com/share/blog-pictures/project_phases.png">
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/project_phases_lowres.png" alt="Project Phases"></a>
+<a href="https://github.com/MissingMaps/img/blob/main/images/project_phases.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/project_phases_lowres.png" alt="Project Phases"></a>
 <p class="caption">Project Phases. CC-BY American Red Cross.</p>
 </figure>
 
 Before the field work, we estimated that there were about 5,000 communities in the target area (based off of OpenStreetMap data). When we actually got on the ground, however, our volunteers visited 7,000 communities. Planning and logistics were a real challenge for this project - here's what 7,000 communities look like across the area:
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/westAfrica-targetcomms.jpg" alt="target comms">
+<img src="https://github.com/MissingMaps/img/blob/main/images/westAfrica-targetcomms.jpg" alt="target comms">
 <p class="caption">Project area and communities visited for rapid assessment and detailed mapping. CC-BY American Red Cross.</p>
 </figure>
 
@@ -48,7 +48,7 @@ Our standard mapping tools consist of Android phones, OpenDataKit and [OpenMapKi
 Here's how POSM works:
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/posm_forblog.jpg" alt="POSM: more than just a cute name">
+<img src="https://github.com/MissingMaps/img/blob/main/images/posm_forblog.jpg" alt="POSM: more than just a cute name">
 <p class="caption">POSM workflow. CC-BY American Red Cross.</p>
 </figure>
 
@@ -59,9 +59,9 @@ Here's how POSM works:
 A mapping hub was established in Guéckédou, Guinea, which served as an operations base and a community engagement facility. Local GIS staff used the mapping hub as a central location to clean incoming data and interact with the local community, building capacity in both the use of OpenStreetMap and general computer, technical, and language skills. POSM also allowed the staff and volunteers to trace features into OpenStreetMap in an offline environment. This process is highlighted [here](https://hi.stamen.com/merging-offline-edits-with-the-posm-replay-tool-2f39a4410d2a#.owg36t8sy). Through partners in each country, local OSM groups formed to continue mapping communities both inside and outside of the initial project area:
 
 <figure>
-<a href="https://twitter.com/osmliberia"><img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/osmliberia.jpg" alt="Pump" style="height:100px; margin-left:15px;"></a>
-<a href="https://twitter.com/osmguinea"><img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/osmguinea.jpg" alt="Pump" style="height:100px; margin-left:15px;"></a>
-<a href="https://twitter.com/osmsierraleone"><img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/osmsl.jpg" alt="Pump" style="height:100px; margin-left:15px;"></a>
+<a href="https://twitter.com/osmliberia"><img src="https://github.com/MissingMaps/img/blob/main/images/osmliberia.jpg" alt="Pump" style="height:100px; margin-left:15px;"></a>
+<a href="https://twitter.com/osmguinea"><img src="https://github.com/MissingMaps/img/blob/main/images/osmguinea.jpg" alt="Pump" style="height:100px; margin-left:15px;"></a>
+<a href="https://twitter.com/osmsierraleone"><img src="https://github.com/MissingMaps/img/blob/main/images/osmsl.jpg" alt="Pump" style="height:100px; margin-left:15px;"></a>
 </figure>
 
 ## Rapid Assessment and Detailed Community Mapping
@@ -73,7 +73,7 @@ Using the vulnerability index and major population centers, 104 communities were
 Based on the data collected and the communities visited, roughly 800 `fixme` location and name tags were removed from the project area in OpenStreetMap. Many of what appeared to be communities were actually seasonal farms or long abandoned villages. Many of the `fixme` tags marked communities that were based on out-of-date maps and government data that was over 50 years old.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/westAfrica-pump.jpg" alt="Pump">
+<img src="https://github.com/MissingMaps/img/blob/main/images/westAfrica-pump.jpg" alt="Pump">
 <p class="caption">Volunteer mapping a water pump during the detailed mapping phase. CC-BY American Red Cross.</p>
 </figure>
 
@@ -91,13 +91,13 @@ Check out some of the analysis already done with the data we collected: [Mapping
 We've also posted pictures from motorbikes and vehicles used in the project to [Mapillary](https://www.mapillary.com/map/im/3hlhf5HEBwR_9XzMb91Rww), so take a look through the 100 GB of photos that we uploaded!
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/westAfrica-motorbike.jpg" alt="motorbike">
+<img src="https://github.com/MissingMaps/img/blob/main/images/westAfrica-motorbike.jpg" alt="motorbike">
 <p class="caption">A Mapillary image captured from a volunteer on motorbike. CC-BY American Red Cross.</p>
 </figure>
 
 Again, this project could not have been completed without the tireless efforts of the 126 Red Cross volunteers who, equipped with a phone and a humanitarian spirit, helped put people on the map. THANKS to everyone who contributed to the project!
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/westAfrica-team.jpg" alt="Team">
+<img src="https://github.com/MissingMaps/img/blob/main/images/westAfrica-team.jpg" alt="Team">
 <p class="caption">Field team leader discussing plans with volunteers in Liberia. CC-BY American Red Cross.</p>
 </figure>

--- a/2017-02-20-fighting-fgm-in-tanzania.md
+++ b/2017-02-20-fighting-fgm-in-tanzania.md
@@ -3,7 +3,7 @@ layout: post
 title: Fighting FGM in Tanzania
 postID: fighting-fgm-in-tanzania
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170220_banner.png
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170220_banner.png
 date: 2017-02-20
 author: Janet Chapman
 excerpt: "I first met Rhobi in a building site in Mugumu, Serengeti,  Tanzania, in September 2014 where she was desperately trying to get a Safe House for girls refusing Female Genital Mutilation finished before the \"cutting season\" started in December.  In the week we spent together I accompanied her and her team as they visited the surrounding villages, telling the villagers the dangers of FGM through debates, drama and dance.  Rhobi almost bled to death from FGM in one of these villages as a 13 year old and has been a passionate advocate for womens' rights ever since."
@@ -19,14 +19,14 @@ I first met [Rhobi](http://hiaragirlpower.blogspot.co.uk/2014/09/rhobis-story-wh
 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170220_girlwsign.png" alt="">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170220_girlwsign.png" alt="">
 <p class="caption">CC BY-SA Janet Chapman</p>
 </figure>
 
 As we bounced along the dusty tracks in a rusty over crowded car, frequently getting lost and stopping to ask for directions, I was frustrated by everyone’s complete lack of maps.  I had been inspired to learn about Openstreetmap at [Wikimania](https://wikimania2014.wikimedia.org/wiki/Programme) London the previous month, and had even printed out basic maps to ask Rhobi to mark villages on before I visited.  That was a failure, as was my mapping attempts that time.  No one I met had a good understanding of where the villages were on paper and I was thwarted by poor connectivity and inadequate tools or understanding.   Later on my trip I was amazed to find my GPS at Zeze, and village of 9000 people showed a completely blank map.  I was 2 hours late visiting Ikondo School after driving round in circles through muddy rivers in torrential rain trying to find it. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170220_communitymeeting.png" alt="">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170220_communitymeeting.png" alt="">
 <p class="caption">CC BY-SA Janet Chapman</p>
 </figure>
 
@@ -36,7 +36,7 @@ When [Maps.Me](http://maps.me/en/home) produced their version that allowed edits
 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170220_mapathon.png" alt="">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170220_mapathon.png" alt="">
 <p class="caption">CC BY-SA Janet Chapman</p>
 </figure>
 
@@ -44,7 +44,7 @@ We’ve now recruited over 900 online volunteers and 199 local mappers.  In our 
 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170220_girlsatcomputers.png" alt="">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170220_girlsatcomputers.png" alt="">
 <p class="caption">CC BY-SA Janet Chapman</p>
 </figure>
 
@@ -55,7 +55,7 @@ Having better maps helped prevent 2257 girls from being cut this year.  However 
 Girls like Bhoke* forcibly cut at 13, her body [thrown into the bush](http://hiaragirlpower.blogspot.co.uk/2015/01/5-girls-bodies-thrown-into-bush.html).  But the tide is turning.  This year saw the first prosecutions against parents and cutters for FGM. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170220_infographic.png" alt="">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170220_infographic.png" alt="">
 <p class="caption">CC BY-SA Janet Chapman</p>
 </figure>
 
@@ -66,7 +66,7 @@ There is more information about this project in this [2 minute video on Al Jazee
 Local mappers are continuing to improve the map by adding the names of missing villages across Tanzania, but we are a volunteer run project with no budget and access to smartphones is a limiting factor.  If anyone has any unwanted phones we can make very good use of them!  Please contact us [here](https://crowd2map.wordpress.com/). 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170220_map.png" alt="">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170220_map.png" alt="">
 <p class="caption">CC BY-SA Janet Chapman, <a target="_blank" href="https://jachapman82.carto.com/builder/4324bc10-f250-11e6-9d00-0ee66e2c9693/embed">web map</a></p>
 </figure>
   

--- a/2017-02-24-posm-cloud.md
+++ b/2017-02-24-posm-cloud.md
@@ -3,7 +3,7 @@ layout: post
 title: POSM Cloud
 postID: posm-cloud
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/posmcloud.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/posmcloud.jpg
 date: 2017-02-24
 author: Dale Kunce
 excerpt: "Portable OpenStreetMap (POSM) can run in the cloud. This walkthrough will help you get your own POSM up and running on Amazon EC2."

--- a/2017-03-03-validation-friday.md
+++ b/2017-03-03-validation-friday.md
@@ -3,7 +3,7 @@ layout: post
 title: "#ValidationFriday"
 postID: validation-friday
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170303_validation-style.png
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170303_validation-style.png
 date: 2017-03-03
 author: Matt Gibb
 excerpt: "Validating tasks is an important part in the Missing Maps process, and we encourage everyone to take part. Learn how you can improve your mapping and contribute to validation! #ValidationFriday"
@@ -44,7 +44,7 @@ If you're a validator and you see a mapper doing a great job, reach out to them!
 Remember all those great badges you can earn on your [Missing Maps User Profile](http://www.missingmaps.org/users/#/)? We're going to start reaching out to those users who have soared to great heights and have been earning their `Task Champion` badges, so that we can encourage users to start validating. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170303_validation-badges.png" alt="Earn your Task Champion and Scrutinizer Badges!">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170303_validation-badges.png" alt="Earn your Task Champion and Scrutinizer Badges!">
 <p class="caption">Earn your Task Champion and Scrutinizer Badges!</p>
 </figure>
 
@@ -82,6 +82,6 @@ Find a simple `buildings only` task, read the instructions, square buildings, al
 There's a great community of Missing Map-ers who are ready to help you learn to validate. We all have the goal of improving maps for vulnerable communities, and we all come to the greater OSM community with different levels of experience. Let's start validating and remember the wise words of Uncle Ben, "With great tasks, comes great validation."
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170303_keep-calm-small.png" alt="Validate">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170303_keep-calm-small.png" alt="Validate">
 <p class="caption">Don't forget to Keep Calm and Validate!</p>
 </figure>

--- a/2017-03-30-padf-in-guatemala.md
+++ b/2017-03-30-padf-in-guatemala.md
@@ -3,7 +3,7 @@ layout: post
 title: PADF in Guatemala
 postID: padf-in-guatemala
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170330_padf-guat-group-pic.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170330_padf-guat-group-pic.jpg
 date: 2017-03-30
 author: George Washington University
 excerpt: Faculty and students at the George Washington University teamed up with the Pan American Development Foundation (PADF) this March to bring digital mapping tools to vulnerable communities in Guatemala.
@@ -19,7 +19,7 @@ Faculty and students at the George Washington University (GWU), including AGS Pr
 “Many urban informal communities are literally not on the map, so when emergencies happen they are hard to assist,” says Marie Price. “Mapping and surveying these areas improve our understanding of life threatening conditions and identify households that face the greatest risk.”  Price worked with colleague Dr. Nuala Cowan, who is an Assistant Professor at GWU and a leader in using open source data and tools for humanitarian purposes.
 
 <figure>
-<img style="display: block;margin:auto; " src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170330_pricecowan.jpg"/>
+<img style="display: block;margin:auto; " src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170330_pricecowan.jpg"/>
 <p class="caption">Dr. Nuala Cowan and Dr. Marie Price with community members</p>
 </figure>
 
@@ -29,7 +29,7 @@ Geography Masters students Andrii Berdnyk and Sudie Brown developed workshops an
 The project began with students at the George Washington University remotely tracing buildings and roads in Ciudad Satélite from satellite imagery on to Open Street Map.  When in Guatemala, the research team worked with community members to validate and correct the maps using field papers.
 
 <figure>
-<img style="display: block;margin:auto; " src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170330_communitymembers.jpg"/>
+<img style="display: block;margin:auto; " src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170330_communitymembers.jpg"/>
 <p class="caption">Community members field validation</p>
 </figure>
 
@@ -39,7 +39,7 @@ The maps and information were then shared with the community for planning purpos
 In addition, the research team worked with students and faculty at Rafael Landívar University to trace buildings and roads using OSM, to use mobile phone-based survey tools to collect information on household vulnerability, infrastructure and disaster preparedness.
 
 <figure>
-  <img style="display: block;margin:auto; " src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170330_unimapping.jpg"/>
+  <img style="display: block;margin:auto; " src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170330_unimapping.jpg"/>
   <p class="caption">Students and Faculty at Rafael Landívar University</p>
 </figure>
 

--- a/2017-07-10-world-refugee-day-2017.md
+++ b/2017-07-10-world-refugee-day-2017.md
@@ -3,7 +3,7 @@ layout: post
 title: Volunteers in Uganda and Turkey Rally to Support Refugees on World Refugee Day
 postID: world-refugee-day-2017
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170710_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170710_banner.jpg
 date: 2017-07-10
 author: Geoffrey Kateregga
 excerpt: "What connects Kampala and Istanbul? You might be thinking that Kampala and Istanbul are worlds apart, but volunteers in both cities rallied around a common cause for World Refugee Day - working together to map priority areas in Uganda that require urgent humanitarian assistance."
@@ -30,7 +30,7 @@ Empowering refugees and host communities are key elements of the Ugandan nationa
 The Humanitarian OpenStreetMap Team (HOT) in Uganda works in tandem with the local organization MapUganda to provide OpenStreetMap (OSM) tools, training, information management products and advisory services to humanitarian organizations working with refugees. HOT provides OSM tools to international organizations, local government and refugee communities, along with training, information management support and advisory services. Several volunteers are periodically trained to use OSM tools, and ready to support the humanitarian community with extensive data collection.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170710_map.jpg" alt="map">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170710_map.jpg" alt="map">
 <p class="caption">Distribution of volunteers trained in using OSM tools</p>
 </figure>
 
@@ -43,26 +43,26 @@ To respond to the situation in Uganda, HOT and [Médecins Sans Frontières Turke
 Participants in Istanbul mapped 2,550 buildings in the Boroli, Olua and Ayilo Refugee Settlements, and completed 75% of the targeted region. They learned about Missing Maps, and HOT and MSF’s work. The majority of participants were new mappers, and were excited to learn about OSM and discover how they could contribute.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170710_pic1.jpg" alt="All in a Day’s Work!">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170710_pic1.jpg" alt="All in a Day’s Work!">
 <p class="caption">All in a Day’s Work: Volunteers show solidarity with refugees during Istanbul’s First Missing Maps Mapathon</p>
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170710_pic2.jpg" alt="People Live There!">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170710_pic2.jpg" alt="People Live There!">
 <p class="caption">People Live There! Istanbul Missing Maps Mapathon participants fill in "blank spots" on the map in the Boroli, Olua and Ayilo Refugee Settlements to facilitate humanitarian aid</p>
 </figure>
 
 ## From Istanbul to Kampala: HOT Uganda Organizes Mapathon on World Refugee Day
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170710_pic3.jpg" alt="Mapathon in Kampala">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170710_pic3.jpg" alt="Mapathon in Kampala">
 <p class="caption">Mapathon in Kampala</p>
 </figure>
 
 On June 20, the HOT team in Uganda organized a mapathon in Kampala, with remote connection from MSF’s office in Yumbe, to contribute to the provisioning of up-to-date information on refugee settlements and hosting communities. The mapathon gathered several volunteers, humanitarian workers and representatives from UNHCR and WFP, and targeted mapping of shelters, main roads, boundaries for Maji Refugee Settlement and Adjumani Town.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170710_pic4.jpg" alt="Opening of the Mapathon">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170710_pic4.jpg" alt="Opening of the Mapathon">
 <p class="caption">Opening of the Mapathon in Kampala, HOT Country Manager with MapUganda colleagues</p>
 </figure>
 

--- a/2017-07-26-posm-update.md
+++ b/2017-07-26-posm-update.md
@@ -3,7 +3,7 @@ layout: post
 title: "POSM 0.7: Faster and better than ever!"
 postID: posm-update
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170726_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170726_banner.jpg
 date: 2017-07-26
 author: Emily Eros, Seth Fitzsimmons
 excerpt: "We are pleased to announce a new and improved version of POSM – now faster and slicker than ever!"
@@ -30,12 +30,12 @@ Additions and improvements include:
 * Various small bugs found and fixes applied
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170726_pic1.jpg" alt="New POSM Admin interface">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170726_pic1.jpg" alt="New POSM Admin interface">
 <p class="caption">POSM's new admin interface makes the device easier to navigate and use. Offline instructions are linked on the left and the fileshare info is easy to find on the home screen. CC-BY American Red Cross</p>
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170726_pic2.jpg" alt="Online and offline instruction guide">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170726_pic2.jpg" alt="Online and offline instruction guide">
 <p class="caption">We wrote a step-by-step instruction guide where project managers can find everything they need to know about getting, setting up, and using a POSM. Troubleshooting tips are included and the full guide can be accessed [online](www.posm.io) or through the POSM itself. CC-BY American Red Cross</p>
 </figure>
 

--- a/2017-07-27-drone-and-street-level-imagery-in-philippines.md
+++ b/2017-07-27-drone-and-street-level-imagery-in-philippines.md
@@ -3,7 +3,7 @@ layout: post
 title: Detailed drone and street-level imagery for mapping in the Philippines
 postID: drone-and-street-level-imagery-in-philippines
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_banner.jpg
 date: 2017-07-27
 author: Dan Joseph
 excerpt: "In May 2017, the American Red Cross and Philippine Red Cross collected detailed aerial and street-level imagery of areas that have been part of a 3-year Typhoon Haiyan (Yolanda) recovery program."
@@ -25,7 +25,7 @@ As part of the response to the disaster caused by Typhoon Haiyan (Yolanda), the 
 Unmanned Aerial Vehicles (UAVs), also known as Remotely Piloted Aircraft Systems (RPAS) or drones, are increasingly used for [humanitarian purposes](http://drones.fsd.ch/en/drones-in-humanitarian-action/). In May 2017, we leveraged drones for comprehensive aerial imagery collection to support the recovery program. High-resolution aerial imagery is a valuable resource when creating value-add information products for response, planning, monitoring, and resilience building activities.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_compare.jpg" alt="satellite vs drone imagery">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_compare.jpg" alt="satellite vs drone imagery">
 <p class="caption">Resolution comparison between satellite imagery available on Google Maps (left) compared to drone imagery</p>
 </figure>
 
@@ -35,7 +35,7 @@ Unmanned Aerial Vehicles (UAVs), also known as Remotely Piloted Aircraft Systems
 When flying drones, it is important to comply with regulations, conduct activities professionally, and operate safely. Failing to do so could result in backlash against the future utilization of the technology. An FAA certified remote pilot from the American Red Cross GIS team as well as a volunteer that is certified were present for the project activities. During planning stages, we talked through the activities with the Philippine Red Cross. Then we communicated with all the local authorities to obtain their approvals. We then obtained all necessary authorizations from the Civil Aviation Authority of the Philippines (CAAP). Preparation for the trip was a several month process!
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_slingshot.jpg" alt="POSM">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_slingshot.jpg" alt="POSM">
 <p class="caption">When flying at 80 meters, kids with slingshots aren't much of a threat but maybe we should have done more information dissemination about our activities! CC-BY Matthew Marek</p>
 </figure>
 
@@ -44,7 +44,7 @@ When flying drones, it is important to comply with regulations, conduct activiti
 We took two fixed-wing drones, an [Event 38](https://twitter.com/Event38) E384 and a [Tuffwing](https://twitter.com/TuffWing) UAV Mapper, as well as a small quadcopter, a [DJI](https://twitter.com/djiglobal) Mavic Pro. Due to some technical challenges, and difficulties finding suitably large and clear areas for landing the fixed-wing drones, almost all our mapping ended up being with the Mavic. Because we had two pilots we ended up procuring a second Mavic after the first week to double our coverage speed.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_mavics.jpg" alt="flying the Mavics">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_mavics.jpg" alt="flying the Mavics">
 <p class="caption">James McDanolds monitors a Mavic in flight while Dan Joseph troubleshoots another, CC-BY Ylla De Ocampo</p>
 </figure>
 
@@ -55,7 +55,7 @@ We took two fixed-wing drones, an [Event 38](https://twitter.com/Event38) E384 a
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_training.jpg" alt="flying the Mavics">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_training.jpg" alt="flying the Mavics">
 <p class="caption">James McDanolds teaches Ylla De Ocampo from the Philippine Red Cross how to pilot the Mavic, CC-BY American Red Cross</p>
 </figure>
 
@@ -65,17 +65,17 @@ We took two fixed-wing drones, an [Event 38](https://twitter.com/Event38) E384 a
 We tested using ground controls points (GCPs) in Barangay Marasbaras. We had 12 large fabric markers with distinct patterns that we placed around the area before collecting imagery. By using handheld Garmin GPS units' waypoint averaging functionality, we could determine more accurate latitude and longitude coordinates for the markers which were then used after image processing to adjust and improve the accuracy of the final map products.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_gcp2.jpg" alt="ground control point">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_gcp2.jpg" alt="ground control point">
 <p class="caption">One of the fabric markers used as a ground control point, CC-BY American Red Cross</p>
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_gcp1.jpg" alt="waypoint averaging">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_gcp1.jpg" alt="waypoint averaging">
 <p class="caption">Waypoint averaging with a Garmin GPS unit, CC-BY American Red Cross</p>
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_gcp3.jpg" alt="gcp visible in aerial imagery">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_gcp3.jpg" alt="gcp visible in aerial imagery">
 <p class="caption">One of the GCPs visible in the aerial imagery, CC-BY American Red Cross</p>
 </figure>
 
@@ -84,7 +84,7 @@ We tested using ground controls points (GCPs) in Barangay Marasbaras. We had 12 
 As we travelled between barangays and walked around the areas, we used a variety of cameras to collect street-level imagery. The geotagged images collected with Sony action cameras, 360<sup>o</sup> cameras, and smart-phones were then uploaded to [Mapillary](https://www.mapillary.com/) where they became part of an ever-growing, community built collection of openly licensed street-level images for the world. The images can provide valuable insights; it is possible to observe signage, the condition of buildings, and other aspects of the environment not visible in vertical aerial/satellite imagery. They allow anyone to [#MapillaryExplore](https://twitter.com/mapillary/status/874978591678791681).
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_mapillary.jpg" alt="collecting mapillary">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_mapillary.jpg" alt="collecting mapillary">
 <p class="caption">Hiding from the sun while <a href="https://www.mapillary.com/app/?lat=10.859070004872933&lng=124.98645779947196&z=17&pKey=61GREpTo2sVH4BfhTSZm6A&focus=photo&x=0.3017540420440399&y=0.6072076945566833&zoom=0" target="\_blank">collecting images</a> with a 360<sup>o</sup> camera mounted on a pole</p>
 </figure>
 
@@ -93,12 +93,12 @@ As we travelled between barangays and walked around the areas, we used a variety
 To process aerial drone imagery, we use an open-source toolkit called [OpenDroneMap (ODM)](https://github.com/OpenDroneMap/OpenDroneMap#opendronemap). ODM can combine the series of images captured during flight(s) over an area of interest into a single georeferenced image file that can be used for GIS purposes. We can perform this process in offline environments, having incorporated ODM into the set of software tools that we can run on a [POSM](https://github.com/posm/posm#posm) portable server. POSM runs on a small piece of hardware that is plugged into a power source and broadcasts a local wifi signal in order to connect devices. When connected to POSM, users can access several pieces of software, such as ODM and other mapping tools, that are normally cloud-based and require an internet connection.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_image-folder.jpg" alt="folder of images">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_image-folder.jpg" alt="folder of images">
 <p class="caption">A folder full of the individual raw images collected over an area</p>
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_posm.jpg" alt="POSM">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_posm.jpg" alt="POSM">
 <p class="caption">Processing imagery on a POSM, CC-BY American Red Cross</p>
 </figure>
 
@@ -109,7 +109,7 @@ To process aerial drone imagery, we use an open-source toolkit called [OpenDrone
 [OpenAerialMap (OAM)](https://openaerialmap.org/) is a repository of openly licensed imagery and map layer services. We uploaded all the processed imagery to OAM so that it would be easily available for us, and others, to access and use.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_oam.jpg" alt="OpenAerialMap">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_oam.jpg" alt="OpenAerialMap">
 <p class="caption">Imagery on OpenAerialMap (OAM)</p>
 </figure>
 
@@ -129,12 +129,12 @@ To coordinate the digital volunteers helping to trace the project areas we used 
 The drone imagery, and the Mapillary images as well, proved useful for detailed, up-to-date tracing of map features into OSM. The improvements over what was possible using only satellite imagery are striking!
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_palanog-before.jpg" alt="before">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_palanog-before.jpg" alt="before">
 <p class="caption">Barangay Palanog 37-A before drone imagery was used to update <a href="https://osm.org/go/44Cii0w6h--" target="\_blank">OSM</a></p>
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_palanog-after.jpg" alt="after">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_palanog-after.jpg" alt="after">
 <p class="caption">Barangay Palanog 37-A after drone imagery was used to update <a href="https://osm.org/go/44Cii0w6h--" target="\_blank">OSM</a></p>
 </figure>
 
@@ -143,6 +143,6 @@ We made all the imagery outputs available through [OAM](https://map.openaerialma
 We've also made the raw datasets of aerial imagery [available](https://docs.google.com/spreadsheets/d/1vX1C0k1TM0op9qQ0m8cXMUsMcUnzw3o7SE5dasOXbf8/edit?usp=sharing) with the intent that they can be used for purposes such as test datasets for the development of tools like ODM. You can check out the imagery in this [web viewer](https://americanredcross.github.io/ttl-imagery/). The outputs will be shared with the communities and local government. The American Red Cross will continue to work with the Philippines Red Cross to utilize the data and think about future use of drones. We will continue to share and progress with our learning, and hopefully fly again soon!
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170727_kids.jpg" alt="flying the Mavics">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170727_kids.jpg" alt="flying the Mavics">
 <p class="caption">Interested kids crowd around to see the screen displaying the status of one of the Mavics as it maps, CC-BY Ylla De Ocampo</p>
 </figure>

--- a/2017-08-10-malawi.md
+++ b/2017-08-10-malawi.md
@@ -3,7 +3,7 @@ layout: post
 title: "Stop the spots: Measles vaccinations in Malawi"
 postID: posm-update
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170810_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170810_banner.jpg
 date: 2017-08-10
 author: Emily Eros, Ashley Schmeltzer
 excerpt: "Measles is one of the most contagious diseases ever known and it is a leading cause of death among children. In June, the American Red Cross supported a measles and rubella immunization campaign in Malawi that targeted nearly 8 million children."
@@ -28,14 +28,14 @@ In June, the American Red Cross supported a measles and rubella immunization cam
 To support this massive effort, the Red Cross assisted with social mobilization in five districts across the country: Lilongwe, Blantyre, Mangochi, Mzimba, and Zomba. Three thousand local Malawi Red Cross volunteers in these districts were trained on key messages and conducted roughly 100,000 house-to-house visits over three days. Volunteers ensured that the households heard about the campaign and provided an opportunity to ask questions about the vaccine and the campaign – providing an important avenue to address the concerns of those who might not otherwise have brought their children to be immunized.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170810_pic1.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170810_pic1.jpg">
 <p class="caption">Malawi Red Cross social mobilization volunteers in Lilongwe. CC-BY American Red Cross</p>
 </figure>
 
 As a special part of this campaign, the volunteers in some areas also collected information from caregivers about their young (12-23 months old) children’s routine immunization status – asking to see the child’s health passport and looking for a measles vaccination record or mark in  in his/her vaccination history. This information enables us to identify younger children have missed routine vaccinations; in the future this could help partners to follow up with those children in specific to ensure that they are reached by the health system.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170810_pic2.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170810_pic2.jpg">
 <p class="caption">Malawian health passport, in which parents record their child’s vaccinations. CC-BY American Red Cross</p>
 </figure>
 
@@ -48,7 +48,7 @@ The American Red Cross GIS team supported the M&RI field activities by introduci
 For the social mobilization, we provided mobile phones for 85 volunteers in Lilongwe (repurposed from the [West Africa project](http://www.missingmaps.org/blog/2017/01/24/west-africa-mapping-hub-end/) and trained them on the [OpenDataKit (ODK)](https://opendatakit.org/) Android app for data collection. Half of the time, these volunteers asked households the additional routine immunization questions. The other half of the time, the volunteers did not. This was randomly set within the ODK survey (link to download ODK survey template) and enabled us to compare the additional time required for the extra data collection, which will help the Red Cross determine whether or not the data collection can be done on a larger scale. We also had a group conducting this work on [paper forms](https://arcmaps.s3.amazonaws.com/share/Malawi_paper_soc_mob_form.docx) as a control group.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170810_pic3.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170810_pic3.jpg">
 <p class="caption">Prepping apps and settings on over 100 phones. CC-BY American Red Cross</p>
 </figure>
 
@@ -65,7 +65,7 @@ Volunteers discussed the campaign with each household and then asked a series of
 When the caregiver did have a health passport for a child, the volunteer also took a photo of the immunization record in the passport. This enables a quality check of the data afterwards.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170810_pic4.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170810_pic4.jpg">
 <p class="caption">Social mobilization visit by a Malawi Red Cross volunteer in Lilongwe. CC-BY American Red Cross</p>
 </figure>
 
@@ -76,12 +76,12 @@ At the end of each day, we visited volunteers at central locations and collected
 The GIS team also supported nationwide real-time monitoring for the RCM. As a collaboration with the Ministry of Health, we trained 58 Red Cross monitors and government health staff from across the country on OpenDataKit for RCM monitoring. These individuals supplied and used their own smartphones for the activities, and we reimbursed them with air credit for the data uploads. During the RCM, they collected and submitted the monitoring results, which fed into an interactive dashboard that displayed the results in real-time. Over the course of the week-long campaign, 73 monitors in 22 districts conducted 440 RCM sets – representing 13,743 children.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170810_pic5.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170810_pic5.jpg">
 <p class="caption">A district health officer checks for a finger mark (indication of having received the measles vaccine) during RCM in a village in Nkhotakota. CC-BY American Red Cross</p>
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170810_pic6.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170810_pic6.jpg">
 <p class="caption">RCM results fed into an interactive online dashboard, accessible for those working on the campaign. (Special thanks to the British Red Cross for assisting with dashboard development!) CC-BY American Red Cross</p>
 </figure>
 
@@ -92,12 +92,12 @@ Each district had a daily meeting during the campaign to discuss daily activitie
 For important base map data, we relied on the contributions of over 3,000 Missing Maps volunteers, who traced nearly 400,000 buildings across Malawi, equating to the homes of roughly 1.7 people. This data played an important role in planning our fieldwork and the logistics required. Additionally, the base data in OpenStreetMap was the background layer in the nationwide RCM dashboard, and for all our analytics and data visualizations. Without the many volunteers who contributed, the data collected would have simply been points on a blank canvas. Many thanks to all who helped with tracing in Malawi!
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170810_pic7.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170810_pic7.jpg">
 <p class="caption">The paper map is not dead! Planning logistics and meet-up locations for social mobilization in Lilongwe. Map data from OpenStreetMap… made possible by Missing Maps volunteers. Thanks! CC-BY American Red Cross</p>
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170810_pic8.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170810_pic8.jpg">
 <p class="caption">OpenStreetMap data with social mobilization locations overlaid. The detail and quality of mapping across Malawi gave us high-resolution to examine and display results for both the RCM and social mobilization activities. CC-BY American Red Cross</p>
 </figure>
 

--- a/2017-09-05-ym-video-challenge.md
+++ b/2017-09-05-ym-video-challenge.md
@@ -3,7 +3,7 @@ layout: post
 title: Join us for our first YouthMappers Video Challenge!
 postID: ym-video-challenge
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170905_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170905_banner.jpg
 date: 2017-09-05
 author: Rachel Levine
 excerpt: "Share your chapters' lessons learned with the wider Missing Maps community by filming a short 5 minute video on Tips and Tricks for Hosting a Mapathon.  Winning video will be featured on the Missing Maps website."

--- a/2017-09-13-ifrc.md
+++ b/2017-09-13-ifrc.md
@@ -3,7 +3,7 @@ layout: post
 title: "IFRC joins Missing Maps"
 postID: ifrc-joins
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170913_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170913_banner.jpg
 date: 2017-09-13
 author: Heather Leson
 excerpt: "We are excited to welcome the newest member of Missing Maps: the International Federation of Red Cross and Red Crescent Societies (IFRC). This is a cross-post from the IFRC's official announcement."
@@ -20,7 +20,7 @@ We are excited to welcome the newest member of the Missing Maps partnership: the
 We are pleased to announce [International Federation of the Red Cross Red Crescent Societies](http://www.ifrc.org/) is joining the Missing Maps Partnership. Missing Maps is an open, collaborative project in which you can help to map areas where humanitarian organisations are trying to meet the needs of vulnerable people – creating open data that can be used for planning, awareness, and analysis. Over 33,000 people have contributed 33 million edits to [OpenStreetMap](https://www.openstreetmap.org/) since Missing Maps was founded in 2014. These contributions have been used to support health interventions, emergency response, and resilience programs. Volunteers, organizations, and humanitarians collaborate in a number of ways: remote mapping, field mapping, and humanitarian activities.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170913_Missing-Maps-HOT-London-Event-photo-by-Harry-Wood-cc-by-sa-20.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170913_Missing-Maps-HOT-London-Event-photo-by-Harry-Wood-cc-by-sa-20.jpg">
 <p class="caption">Missing Maps (HOT) London Event, photo by Harry Wood, CC BY-SA</p>
 </figure>
 

--- a/2017-09-18-belize.md
+++ b/2017-09-18-belize.md
@@ -3,7 +3,7 @@ layout: post
 title: "Building capacity in the Caribbean"
 postID: caribbean
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170918_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170918_banner.jpg
 date: 2017-09-18
 author: Ashley Schmeltzer
 excerpt: "This spring and summer, the American Red Cross led training-of-trainers in Belize and Jamaica to build the mapping skills and knowledge of local Red Cross and government staff - here's a quick update of our work."
@@ -26,7 +26,7 @@ In Belize, for example, we led a workshop with 18 participants from agencies wit
 3. Understanding the ways the data can be used for decision-making
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20170918_pic1.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20170918_pic1.jpg">
 <p class="caption">Workshop participants in Belize, CC-BY American Red Cross</p>
 </figure>
 

--- a/2017-11-07-wafrica_geoweek.md
+++ b/2017-11-07-wafrica_geoweek.md
@@ -3,7 +3,7 @@ layout: post
 title: "OSM in West Africa: The Mapping Continues"
 postID: osm-wafrica
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20171107_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20171107_banner.jpg
 date: 2017-11-07
 author: David Luswata, Emily Eros, and local contributors
 excerpt: "Mapping in West Africa continues, thanks to dedicated OSM communities in Liberia, Guinea, and Sierra Leone. Here's what they are planning for GeoWeek 2017."

--- a/2018-04-09-canaan-drones.md
+++ b/2018-04-09-canaan-drones.md
@@ -3,7 +3,7 @@ layout: post
 title: Drones over Canaan, Haiti
 postID: canaan-drones
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180409_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180409_banner.jpg
 date: 2018-04-09
 author: Matthew Gibb and Dan Joseph
 excerpt:  Canaan, one of the most populated areas in Haiti, continues to evolve and grow. In December 2017, the American Red Cross recently covered 35 square kilometers of this area with new drone imagery to assist with population estimates, disaster preparedness programming, and updating OpenStreetMap.
@@ -36,7 +36,7 @@ Given the Mavic Pro’s size and sensor capabilities, it took a large number of 
 To improve accuracy of our orthomosaic, at each launch point, ground control points (GCPs) were used. GPS coordinates are taken at the center of the GCP and when the orthomosaic is created, it can be georectified by adjusting the latitude and longitude of the GCP in the image to match those of the collected coordinates.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180409_gcp-placed.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180409_gcp-placed.jpg">
 <p class="caption">Ground control point placed near launch site, CC-BY American Red Cross</p>
 </figure>
 
@@ -65,7 +65,7 @@ Once we were setting up at a launch point, the community focal point would work 
 In addition to flights, we used two Sony Action Cameras to capture street level imagery as we drove throughout Canaan. The imagery of the area can be viewed on [Mapillary](https://www.mapillary.com/app/?lat=18.652149722222248&lng=-72.29545138888886&z=17&pKey=qesHt-3rIoVgYZaYtguNsQ&focus=photo) and [OpenStreetCam](http://openstreetcam.com/details/990741/207). Both forward facing and side facing images were captured.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180409_mapillary.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180409_mapillary.jpg">
 <p class="caption">Camera collecting street level imagery for Mapillary and OpenStreetCam, CC-BY American Red Cross</p>
 </figure>
 
@@ -80,14 +80,14 @@ Over 6 days of flying (with excessive wind grounding us for 2 additional days), 
 At the American Red Cross, we support the development and use of open source software. We are fans of the OpenDroneMap project. Due to the magnitude of images that were collected, we processed the images in 66 separate groups, each less 1000 images, making sure that there was significant overlap of these areas for continuity when later merging them. It took several attempts and and multiple methodologies to identify a process that resulted in a quality orthoimage to be shared. Things that could go wrong, did: hard drives filled up, uploads failed, GDAL installations were messed up, downloads failed, and more. OpenDroneMap has since been improved to better handle such large image sets, so it'll be a lot easier next time!
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180409_processing.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180409_processing.png">
 <p class="caption">Collected imagery and the processing areas, CC-BY American Red Cross</p>
 </figure>
 
 Once the merged orthomosaic was complete, we adjusted the georeferencing of the mosaic using the ground control points that had been laid out at each launch site.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180409_gcp-flight.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180409_gcp-flight.png">
 <p class="caption">Ground control point flag and red marker showing corresponding collected GPS coordinates in an image from the DJI Mavic Pro, CC-BY American Red Cross</p>
 </figure>
 

--- a/2018-04-24-madagascar-field-mapping.md
+++ b/2018-04-24-madagascar-field-mapping.md
@@ -3,7 +3,7 @@ layout: post
 title: 4 weeks in Madagascar with OSM-Mada & PHF/PHM - Disaster Risk Reduction project
 postID: cartong-madagascar-field-mapping
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180424_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180424_banner.jpg
 date: 2018-04-24
 author: Martin Noblecourt
 excerpt: "As part of a new natural Disaster Risk Reduction project launched in partnership with the French NGO <a href='http://pohf.org/'>Pompiers Humanitaires Français (PHF)</a> and the <a href='https://www.facebook.com/OpenStreetMap.Madagascar/'>local OpenStreetMap community</a>, Missing Maps member CartONG implemented a 4-week mission in Madagascar in March 2018. The objectives: raising awareness on data sharing, collecting data in the field and producing maps!"
@@ -14,7 +14,7 @@ lang: en
 ---
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180424_atsinanana.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180424_atsinanana.jpg">
 </figure>
 
 As part of a new natural Disaster Risk Reduction project launched in partnership with the French NGO Pompiers Humanitaires Français (PHF) and the local OpenStreetMap community, Missing Maps' member CartONG implemented a 4-week mission in Madagascar in March 2018. The objectives: raising awareness on data sharing, collecting data in the field and producing maps!
@@ -26,7 +26,7 @@ For several years, CartONG has developed and maintained friendly relations with 
 ## Launch of a Disaster Risk Reduction Project with PHF
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180424_workgroup1.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180424_workgroup1.jpg">
 </figure>
 
 In 2017, we started a new project in partnership with the NGO Pompiers Humanitaires Français (PHF) – French Humanitarian Firefighters, which has been operating in eastern Madagascar (Atsinanana region) since 2010. In particular, PHF initiated the creation of an emergency and civil protection centre in Vatomandry in 2013.
@@ -38,7 +38,7 @@ To this end, we organized several Missing Maps mapathons between October 2017 an
 ## 4 weeks in the field
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180424_workgroup2.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180424_workgroup2.jpg">
 </figure>
 
 This preparatory phase led to a mission in Madagascar organized from March 3rd to 27th 2018, thanks to the decisive support of the [CNES](http://cnes.fr/en) (the French Space Agency). After a preliminary phase in Antananarivo with the Malagasy OSM community – during which a data sharing workshop, similar to [the one organized in January 2018 in the DRC](http://www.cartong.org/activity/building-data-collaborative-support-sdgs-health-and-wash-malawi-and-drc), was organized – the combined CartONG & OSM-Mg team then left for the Atsinanana region to collect data in the field for 3 weeks.
@@ -48,7 +48,7 @@ The mission was disrupted by the passage of the [tropical storm Eliakim](http://
 ## A mission offering a wealth of learning opportunities
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180424_fieldwork.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180424_fieldwork.jpg">
 </figure>
 
 This mission was a rich human and technical experience. It was also one of the first missions organized in full autonomy by CartONG, that is to say without the support of an international NGO in the field.

--- a/2018-06-25-mapswipe-story.md
+++ b/2018-06-25-mapswipe-story.md
@@ -3,7 +3,7 @@ layout: post
 title: MapSwipe - the story continues
 postID: mapswipe-story
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180625_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180625_banner.jpg
 date: 2018-06-25
 author: Jess Cahill
 excerpt: MapSwipe volunteer Jess Cahill looks at current MapSwipe developments and how the crowdmapping app is helping survivors of sexual violence in Haiti.
@@ -32,7 +32,7 @@ In 2015 MSF opened the Pran Men’m (“Take My Hand”) clinic, which provides 
 Nell explained that in a large capital city one clinic isn’t accessible to everyone, so there are several outreach sites and MSF are currently carrying out a household survey to look at how they can increase access to services, particularly within the 72 hour window.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180625_banner_port-au-prince.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180625_banner_port-au-prince.jpg">
 <p class="caption">Parts of Port-au-Prince are densely populated, Photo: Benedicte Kurzen/Noor</p>
 </figure>
 
@@ -53,7 +53,7 @@ You may be interested in the [MapSwipe Analytics website](http://mapswipe.heigit
 Talking to humanitarian professionals revealed it was important to make the data as open and available as possible so anyone can refer to it when needed, without specialist equipment. So if you look at a project online you can see at a glance where the areas of likely population are. That could be pretty useful in an emergency.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180625_haiti-data.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180625_haiti-data.jpg">
 <p class="caption">Part of the Haiti project as visualised on the MapSwipe Analytics website: green areas have been marked by MapSwipe users as populated, yet you can see these buildings are not on the base map.</p>
 </figure>
 

--- a/2018-08-17-community-mapping-in-vietnam.md
+++ b/2018-08-17-community-mapping-in-vietnam.md
@@ -3,7 +3,7 @@ layout: post
 title: Community Mapping in Viet Nam
 postID: community-mapping-in-vietnam
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180815_banner.png
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180815_banner.png
 date: 2018-08-17
 author: Jennifer Duong & Rachel Levine
 excerpt: This summer, the American Red Cross GIS team held a weeklong training for the Viet Nam Red Cross Society (VNRC) and the American Red Cross Viet Nam Delegation to cover mobile data collection and community mapping best practices. Interested in hosting your own community mapping trip or just curious? Learn more about our training and agenda here.
@@ -22,14 +22,14 @@ In June, members of the American Red Cross GIS team traveled to Hoi An, Viet Nam
 Each year, Central Viet Nam is affected by several major flood events. In recent a recent assessment, The United Nations Institute for Training and Research (UNITAR) published a [map](http://unosat-maps.web.cern.ch/unosat-maps/VN/FL20171106VNM/UNOSAT_A3_FL20171106VNM_QuangNam_Portrait.pdf) that analyzed how many people were  affected by floodwaters in this coastal area following tropical cyclone DAMREY-17 (highlighted in red).
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180815_map.jpg" height="400px">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180815_map.jpg" height="400px">
 <p class="caption">UNITAR Viet Nam Quang Nam Province, Photo: UNITAR</p>
 </figure>
 
 This flood analysis indicates that approximately 190,000 people were affected by Cyclone DAMREY-17 in Quang Nam Province. Having access to maps like these and being able to analysis how far residents live from coastal fronts allow community planners and the VNRC to prepare flood strategies and mitigate large impacts from major storm surges and landslides. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180815_fisherman.jpg" height="400px">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180815_fisherman.jpg" height="400px">
 <p class="caption">Man fishing near river in Hoi An, Viet Nam, Photo: Ⓒ American Red Cross | Dale Kunce</p>
 </figure>
 
@@ -38,7 +38,7 @@ This flood analysis indicates that approximately 190,000 people were affected by
 One way the VNRC prepares for annual flood events is by routinely completing Vulnerability Capacity Assessments (VCAs). These were traditionally done by hand, making results hard to share and refer back to.  When the teams incorporate OpenStreetMap (OSM) into a workflow to complete the VCA, this can result in a more detailed and accurate spatial layout of communities. We can use OSM data layers (like historic flood levels, transportation routes, population densities, etc.) to enhance VCAs so they are more informative to decision-makers. Additionally, understanding where communities are most vulnerable allows us to identify and resolve gaps in our data, ensuring that future plans improve over time. Lastly, using OSM allows us to digitize our results and share the data we created with the wider community for further discussions and improvements.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180815_VCA.jpg" height="400px">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180815_VCA.jpg" height="400px">
 <p class="caption">VCAs done by hand, Photo: Ⓒ American Red Cross | Dale Kunce</p>
 </figure>
 
@@ -70,7 +70,7 @@ Activity: Learn how to use Overpass Turbo to extract mapping data and QGIS to pr
 Goal: Create individual maps from VCAs, complete with traditional mapping markers (including a title, north arrow, and legend)
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180815_volunteerthinking.jpg" height="400px">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180815_volunteerthinking.jpg" height="400px">
 <p class="caption">VCAs done by hand, Photo: Ⓒ American Red Cross | Linh Vu</p>
 </figure>
 
@@ -87,6 +87,6 @@ After the training, participants are able to:
 - Take their new strategies learned and data collected into QGIS to produce a professional map that can be used in meetings with partners and stakeholders
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180815_hoianstreet.jpg" height="400px">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180815_hoianstreet.jpg" height="400px">
 <p class="caption">Participants head out to map the community, Photo: Ⓒ American Red Cross | Rachel Levine</p>
 </figure>

--- a/2018-09-24-foss4g-gathering-sitevisits.md
+++ b/2018-09-24-foss4g-gathering-sitevisits.md
@@ -27,7 +27,7 @@ These were the remarks from January Makamba, the Tanzanian Minister of State for
 One of the highlights of the week was attending a tour of a number of [Humanitarian OpenStreetMap Team](https://www.hotosm.org/) (HOT) supported local mapping projects throughout Dar Es Salaam.  Members of MapAction, the American Red Cross, the International Federation of Red Cross Red Crescent (IFRC), and new HOT staff joined together to visit five different learning environments. HOT is currently supporting multiple projects throughout Tanzania and Africa and works with local universities, communities, technology companies, Red Cross National Societies, and government organisations. Through these projects HOT aims to use [OpenStreetMap](https://www.openstreetmap.org/#map=5/54.910/-3.432) to create sophisticated and highly-accurate maps of Dar Es Salaam to support the local community. With two of the newest Missing Maps members (MapAction and the IFRC) along for the visit, this was a great opportunity to learn more about HOT programming and understand how many of our individual organizations mapping projects overlap with other organizations work.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180921_hospital.jpeg" height="400px">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180921_hospital.jpeg" height="400px">
 <p class="caption">Ground control point placed near launch site, Photo: Ⓒ MapAction | Steve Penson</p>
 </figure>
 
@@ -40,7 +40,7 @@ Over time, as more data is collected, it will be possible to build a clear pictu
 The project, although currently in its very early stages, could have a huge impact throughout Dar and beyond. The project is innovative and remarkably simple, with strong parallels to how Dr. John Snow used spatial data to understand and explain a health problem in London. Using open source maps, local knowledge and local expertise, it will be possible to identify areas of need at a hyperlocal scale with very little impact on hospital resources.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180921_shinamap.jpeg" height="400px">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180921_shinamap.jpeg" height="400px">
 <p class="caption">Shina map with ward boundaries.</p>
 </figure>
 
@@ -51,7 +51,7 @@ The tour also took us to see the work of the much larger Tanzanian mapping proje
 Full, highly detailed, regional drain infrastructure data has now been mapped and, as the community continues to develop, local projects have sprung up with the aim of adding even further detail to the map. The ingenious use of homemade drones and locally made elevation sensors is helping to develop an accurate terrain and elevation model of the region through the use of locally collected Earth Observation data. Through the collection of this data it will not only be possible to understand those affected by floods but will also enable the development of accurate flood plain maps which can be used to identify the people and areas at most risk to flooding.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180921_VCA.jpg" height="400px">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180921_VCA.jpg" height="400px">
 <p class="caption">Community members come together to identify hazards in their Ward, Photo: Ⓒ American Red Cross | Rachel Levine</p>
 </figure>
 

--- a/2018-09-24-posm-release.md
+++ b/2018-09-24-posm-release.md
@@ -3,7 +3,7 @@ layout: post
 title: "POSM 0.8 Big Changes"
 postID: posm-update
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20180924_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20180924_banner.jpg
 date: 2018-09-24
 author: Dan Joseph and Seth Fitzsimmons
 excerpt: "We’ve just released a new version of POSM with many exciting changes."

--- a/2018-12-03-mapping-in-myanmar.md
+++ b/2018-12-03-mapping-in-myanmar.md
@@ -3,7 +3,7 @@ layout: post
 title: "One Map Myanmar and Phandeeyar"
 postID: mapping-in-myanmar
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20181203_banner.png
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20181203_banner.png
 date: 2018-09-24
 author: Jennifer Duong
 excerpt: "In May 2018, the American Red Cross GIS team trained members of One Map Myanmar and Phandeeyar in a weeklong data collection training (a training-of-trainers) in Yangon. After this, these trainers trained Red Cross volunteers in Mawlamyine, and then, they went to collect data for this project."
@@ -18,7 +18,7 @@ lang: en
 The American Red Cross has been working alongside the Myanmar Red Cross to better understand where critical infrastructure and roads are to inform decision making during major disasters, like floods and cyclones. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20181203_1.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20181203_1.png">
 <p class="caption">Planning Mawlamyine City mapping, CC-BY Kyawzayar Linn</p>
 </figure>
 
@@ -35,7 +35,7 @@ In May 2018, the American Red Cross GIS team trained members of [One Map Myanmar
 Below, is a snapshot of how the city of Mawlamyine was divided into mapping tasks and the smaller squares demonstrate areas of higher urban density. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20181203_2.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20181203_2.png">
 <p class="caption">Tasking Manager project squares</p>
 </figure>
 
@@ -74,7 +74,7 @@ In Myanmar, the Red Cross and other organizations are interested in seeing the d
 OpenStreetMap and other forms of open data (i.e. Humanitarian Data Exchange) are great examples of open-source platforms that allow ministries, planning agencies, and humanitarian teams to share common data sets needed for disaster planning and mitigation.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20181203_3.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20181203_3.png">
 <p class="caption">Discussing open data, CC-BY Kyawzayar Linn</p>
 </figure>
 
@@ -83,19 +83,19 @@ Before this activity took place, there were about 113 POIs on the map for the ci
 Using the [OSM Analytics Tool](https://osm-analytics.org/) we can see how many buildings were in this area before and after the new data were brought into OSM.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20181203_4.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20181203_4.png">
 <p class="caption">OSM before and after</p>
 </figure>
 
 The below animation, produced from HOT’s [Visualize Change Tool](http://visualize-change.hotosm.org/) also shows the progress of the features added in OSM over time for the entire area.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20181203_5.gif">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20181203_5.gif">
 <p class="caption">Mapping progress visualized</p>
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20181203_6.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20181203_6.png">
 <p class="caption">Mapping statistics</p>
 </figure>
 
@@ -106,7 +106,7 @@ We want to thank our partners [One Map Myanmar](https://portal.onemapmyanmar.inf
 If you would like to get involved with Missing Maps and our projects in Myanmar, please consider helping us with our efforts to map the Ayeyarwady Delta. Tasks and their priority levels can be found here: https://tasks.hotosm.org/contribute?difficulty=ALL&text=Ayeyarwady 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20181203_7.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20181203_7.png">
 <p class="caption">Training participants, CC-BY Rachel Levine / American Red Cross</p>
 </figure>
 

--- a/2019-01-08-odk-collect-improvements.markdown
+++ b/2019-01-08-odk-collect-improvements.markdown
@@ -3,7 +3,7 @@ layout: post
 title: "Supporting Open Data Kit"
 postID: supporting-open-data-kit
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190108_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190108_banner.jpg
 date: 2019-01-08
 author: Dan Joseph
 excerpt: "The Open Data Kit (ODK) community produces free and open-source software for collecting, managing, and using data in resource-constrained environments. The various ODK tools enable cost effective, scalable, and user-friendly implementation of mobile data activities. The American Red Cross was able to support improvements to ODK."
@@ -30,7 +30,7 @@ One of the key components is ODK Collect, an Android app enabling users to retri
 Staff and volunteers of the Red Cross Red Crescent network are among the 2.5 million users in the past year of ODK Collect and other ODK software like the Aggregate server and the Briefcase desktop app. Conducting damage assessments and registering people for relief distributions are two of the many ways the technology can be used to improve the efficiency and impact of humanitarian action.
 
 <figure>
-<img alt="tweets from Namibia Red Cross and Indian Red Cross about using ODK" src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190108_supporting-odk-society-tweets.png">
+<img alt="tweets from Namibia Red Cross and Indian Red Cross about using ODK" src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190108_supporting-odk-society-tweets.png">
 <p class="caption">Tweets from Namibia Red Cross and Indian Red Cross about using ODK</p>
 </figure>
 
@@ -53,7 +53,7 @@ Each idea went through an open feedback and consultation phase. Conversations oc
 The American Red Cross funded a data export option that allows the user to get their survey data in a GeoJSON geographic file format instead of the standard spreadsheet. The functionality makes it easier to use the data in a GIS or other downstream tool. The functionality was intended to be implemented in both Aggregate and Briefcase. Briefcase v1.13 included the feature  for both the graphical user interface and via command line. Implementing the feature in Aggregate with Google App Engine support, a key part of many existing server deployments, was going to be too costly so we pivoted that funding into additional features (see the last section below). The community discussion for the feature can be found on the [forum](https://forum.opendatakit.org/t/add-a-geojson-export-to-briefcase-and-aggregate/15184). The improvement was tracked and implemented on [GitHub](https://github.com/opendatakit/roadmap/issues/26) and released in [Briefcase v1.13](https://forum.opendatakit.org/t/odk-briefcase-v1-13/16442). 
 
 <figure>
-<img alt="a tweet from @OpenDataKit about the Briefcase release" src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190108_supporting-odk-tweet-briefcase.png">
+<img alt="a tweet from @OpenDataKit about the Briefcase release" src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190108_supporting-odk-tweet-briefcase.png">
 <p class="caption">A tweet from <a href="https://twitter.com/i/web/status/1066995088511897600" target="_blank">@OpenDataKit about the Briefcase release</a></p>
 </figure>
 
@@ -62,7 +62,7 @@ The American Red Cross funded a data export option that allows the user to get t
 We funded an optional feature to occasionally collect GPS coordinates in the background to provide evidence that data was collected in a particular place. There are many legitimate use-cases for this feature but also the potential for abuse; the community discussion around this feature included a good debate about privacy. The discussion for the feature can be found on the [forum](https://forum.opendatakit.org/t/collect-extend-audit-log-to-include-gps-coordinates/15162). The improvement was released in [Collect v1.20 Beta](https://forum.opendatakit.org/t/odk-collect-v1-20-beta/18021) along with related updates to ODK XForms spec, pyxform, XLSForm Online, XLSForm Offline, and the user [documentation](https://docs.opendatakit.org/form-audit-log/).
 
 <figure>
-<img alt="a tweet from @OpenDataKit about the ODK Collect release" src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190108_supporting-odk-tweet-odk-audit.png">
+<img alt="a tweet from @OpenDataKit about the ODK Collect release" src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190108_supporting-odk-tweet-odk-audit.png">
   <p class="caption">A tweet from <a href="https://twitter.com/arphp/status/1100019065882583041" target="_blank">@OpenDataKit about the Collect release</a></p>
 </figure>
 

--- a/2019-01-22-belize-mapping.md
+++ b/2019-01-22-belize-mapping.md
@@ -3,7 +3,7 @@ layout: post
 title: "Mapping for disaster risk reduction in Belize"
 postID: belize-return
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190122_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190122_banner.jpg
 date: 2019-01-22
 author: Ashley Schmeltzer and Dan Joseph
 excerpt: "In September 2017, Ashley Schmeltzer, a GIS Officer with American Red Cross, led a community mapping training with Belize Red Cross. She was invited back, and was accompanied this time by her colleague Dan Joseph, to conduct a more advanced mapping training that included sessions on the use of drones for mapping."
@@ -18,7 +18,7 @@ lang: en
 In September 2017, Ashley Schmeltzer, a GIS Officer with American Red Cross, led a [community mapping training](http://www.missingmaps.org/blog/2017/09/18/belize/) with Belize Red Cross. She was invited back, and was accompanied this time by her colleague Dan Joseph, to conduct a more advanced mapping training that included sessions on the use of drones for mapping. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190122_classroom.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190122_classroom.jpg">
 <p class="caption">Ashley leading a discussion on <a href="https://wiki.openstreetmap.org/wiki/Map_Features">OSM map features</a> attribute tagging. CC-BY American Red Cross</p>
 </figure>
 
@@ -42,12 +42,12 @@ Disaster preparedness and response is more effective when organizations can effe
 We look forward to hearing about how the participants are able to incorporate the various technological tools and mapping methodologies into their future work. And hopefully we can visit Belize again to continue the teaching and learning that happens for everyone involved in activities like this.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190122_pilot.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190122_pilot.jpg">
 <p class="caption">Launching and practicing manual control of the Belize Red Cross drone. CC-BY American Red Cross</p>
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190122_rain.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190122_rain.jpg">
 <p class="caption">A little rain didn’t stop us! Participants were well prepared with plastic sheet protectors and umbrellas.  CC-BY American Red Cross</p>
 </figure>
 

--- a/2019-05-23-urban-improvement-burkina-faso.md
+++ b/2019-05-23-urban-improvement-burkina-faso.md
@@ -3,7 +3,7 @@ layout: post
 title: Supporting a urban improvement project in precarious neighborhoods in Burkina Faso
 postID: urban-improvement-burkina-faso
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190523_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190523_banner.jpg
 date: 2019-05-23
 author: Martin Noblecourt
 excerpt: "In March 2019, Missing Maps member CartONG carried out a 2-weeks mission in Burkina Faso in support of the Yaam Solidarité association. Here is a look back at the mobile data collection and mapping support we provided and the collaborative and sustainable approach we implemented."
@@ -22,7 +22,7 @@ Collaborative mapping, open data and new "low tech" geographic information techn
 Since 2010, Yaam Solidarité has been running a project in Boassa to improve housing and living conditions, which is supported by the French association [Craterre](http://craterre.org/) and funded by the [Abbé Pierre Foundation](http://www.fondation-abbe-pierre.fr/nos-actions/agir-au-dela-des-frontieres/au-burkina-faso-une-nouvelle-echelle-de-cooperation). To provide adequate technical support and carry out this project, CartONG mobilized its volunteer community and worked closely with the OSM community in Burkina Faso.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190523_location.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190523_location.jpg">
 </figure>
 
 ## Objective 1: Create a basic map of the area using the OpenStreetMap platform and crowd sourcing
@@ -32,11 +32,11 @@ In the first phase of the project, CartONG organized 8 mapathons in Lyon, Grenob
 At the end of this first stage, the Boassa district was finally visible on a map, which was then enriched during the second phase of the project that took place on site in Ouagadougou.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190523_before.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190523_before.jpg">
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190523_after.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190523_after.jpg">
 </figure>
 
 ## Objective 2: Collect data in the field through practical and easy-to-use technological solutions and an inclusive approach
@@ -50,7 +50,7 @@ Participants were trained in using OsmAnd and OSM Tracker for geographic data co
 These data collection workshops proved to be a real opportunity to promote collaboration between the local association, members of the neighborhood committee, residents, young students and OSM members, and to promote everyone's knowledge and experience, while allowing them to take better ownership of the project and greater control over their territory and its related challenges.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190523_collection.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190523_collection.jpg">
 </figure>
 
 ## Objective 3: Facilitate the reuse of maps and data and ensure their sustainability in the medium and long term
@@ -60,7 +60,7 @@ All the data produced during the 8 mapathons in France and the data collected in
 As part of the workshops held on site, Yaam Solidarity members were trained in data manipulation on OSM so that they would be able to continue mapping their neighborhood and enrich the database independently of the presence of another actor such as CartONG, and over the long term. This wonderful source of information now makes the inhabitants of the informal district of Boassa visible on the map, as well as the economic activities and initiatives that exist locally. It also highlights other more problematic aspects such as the lack of access to basic services, the risks in terms of accessibility of emergency services, or the evolution and changes in public spaces.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190523_analysis.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190523_analysis.jpg">
 </figure>
 
 At the same time, the Yaam Solidarity association, which works on the spot, can now use this map to call out public authorities or potential donors to address the existing issues in the area. The map will also be used to raise awareness among residents to better plan the urbanization of the district, protect themselves from high-risk areas or preserve road spaces in an effort to ensure a certain quality of life in the district.

--- a/2019-08-07-posm-9-release.markdown
+++ b/2019-08-07-posm-9-release.markdown
@@ -3,7 +3,7 @@ layout: post
 title: "POSM 0.9 - Passel of POSMs"
 postID: posm-passel
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190807_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190807_banner.jpg
 date: 2019-08-07
 author: Dan Joseph, Seth Fitzsimmons
 excerpt: "OpenDroneMap (ODM) is an open ecosystem of solutions for collecting, processing, analyzing and displaying aerial data. American Red Cross has used it when conducting drone mapping and trainings with the Philippines Red Cross, Haitian Red Cross, and Belize Red Cross. We’re excited to have been able to fund some recent improvements that create exciting opportunities when running ODM with POSM, while also benefiting the overall ODM project. The newest POSM release brings in the ODM updates and lets you distribute the processing of large image sets across a passel of POSMs. "
@@ -27,7 +27,7 @@ Why invest in open source? American Red Cross could have purchased many years of
 
 
 <figure>
-<img alt="the WebODM interface" src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190807_culasi.png">
+<img alt="the WebODM interface" src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190807_culasi.png">
 <p class="caption">The WebODM interface on a POSM showing a completed processing task</p>
 </figure>
 

--- a/2019-08-08-kouroussa-guinea-msf.md
+++ b/2019-08-08-kouroussa-guinea-msf.md
@@ -3,7 +3,7 @@ layout: post
 title: Open data production session for resilience against severe Malaria of children 0-5 years organized by MSF
 postID: kouroussa-guinea-msf
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190808_kouroussa_guinea_msf_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190808_kouroussa_guinea_msf_banner.jpg
 date: 2019-08-08
 author: Emmanuel Kourouma
 excerpt: "Through the Missing Maps project, Médecins Sans Frontières (MSF) supports initiatives like the 2-week mapathon that took place in Conakry, Guinea from May 8-22, 2019. This event was able to bring together up to 25 young people that with their volunteering work, helped MSF to get important geographical data in order to run operations on a massive area as the Kouroussa Prefecture in Guinea-Conakry. Here is a translation of the Blog of Emmanuel Kourouma from GeoSynapse in Guinea, about their collaboration with MSF. "
@@ -24,33 +24,33 @@ _\*GeoSynapse is a national association promoting the use of GIS and Open Source
 Médecins Sans Frontières (MSF) is a private charitable non-profit and humanitarian organization. Founded in 1971, it offers emergency medical assistance in situations such as armed conflict, natural disasters, epidemics and famines around the world. This emergency medical assistance implies a good knowledge of the roads, tracks and paths of the area of intervention to access them. Production of accurate maps of the area will help teams perform epidemiological analyses, monitor diseases and plan their logistics. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190808_kouroussa_guinea_msf_1.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190808_kouroussa_guinea_msf_1.jpg">
 </figure>
 
 Within the scope of humanitarian aid, MSF responds to various health needs. Which include an emergency response to disease outbreaks in Kouroussa prefecture and Sanguiana subprefecture, such as malaria among children under 5 years of age. The MSF organization uses mapping as a decision-making tool based on the production of Open Data (roads, tracks and paths). 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190808_kouroussa_guinea_msf_2.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190808_kouroussa_guinea_msf_2.jpg">
 </figure>
 
 According to his needs, MSF organized a two-week Mapathon session by bringing together 30 mappers from the GeoSynapse Guinea organization for the digitization of the "roads, tracks, paths and rivers" of the Sanguiana Sub-Prefecture and of the Kouroussa prefecture. This session started with a brief and brilliant presentation of OpenStreetMap and an upgrade of the various mappers on JOSM (mapping software) for a better apprehension of the tool. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190808_kouroussa_guinea_msf_3.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190808_kouroussa_guinea_msf_3.jpg">
 </figure>
 
 This capacity building allowed the mappers to achieve the objective set by being efficient in the digitization of the entities of the various tasks created on the [HOT tasking manager](https://tasks.hotosm.org/project/6004) of which in total six (6) and two (2) others on the [Francophonelibre tasking manager](http://taches.francophonelibre.org/project/306) over the area of intervention where children from 0 to 5 are facing severe malaria. It was a real success for the whole of the team to help MSF to produce geographical data of the area of intervention while having mapped and completed 100% of the created tasks needed for the project. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190808_kouroussa_guinea_msf_4.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190808_kouroussa_guinea_msf_4.jpg">
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190808_kouroussa_guinea_msf_5.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190808_kouroussa_guinea_msf_5.jpg">
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20190808_kouroussa_guinea_msf_6.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20190808_kouroussa_guinea_msf_6.jpg">
 </figure>
 
 This project aimed to map the sub-prefecture of Sanguina and Kouroussa prefecture affected by humanitarian crises as epidemics. Building on HOT disaster mapping projects, Missing Maps tasks allowed preventive mapping of priority countries to facilitate humanitarian response, medical activities and resource allocation in a crisis. 

--- a/2019-10-01-MapSwipe-v2.md
+++ b/2019-10-01-MapSwipe-v2.md
@@ -3,7 +3,7 @@ layout: post
 title: "MapSwipe 2.0"
 postID: mapswipe-2.0
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191001_mapswipe-grid.png
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191001_mapswipe-grid.png
 date: 2019-10-01
 author: Jessica Bergmann
 excerpt: "In 2015, MapSwipe began as a solution to a complex question: how do we better identify where communities and populations are, allowing mapping to be more efficient and effective? Using a simple mobile app, volunteers are able to swipe through a series of satellite images, tapping in areas where they find features. MapSwipe can be used anywhere, at any time, which provides an easy access point for individuals to contribute to the Missing Maps project without being restricted to their laptop. That was MapSwipe then – this is MapSwipe now."
@@ -22,7 +22,7 @@ Using a simple mobile app, volunteers are able to swipe through a series of sate
 **That was MapSwipe then – this is MapSwipe now.**
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191001_screenshot-new-project-types.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191001_screenshot-new-project-types.png">
 <p class="caption">Two new project types are available in MapSwipe 2.0</p>
 </figure>
 

--- a/2019-10-25-hackaton-czech-republic.md
+++ b/2019-10-25-hackaton-czech-republic.md
@@ -3,7 +3,7 @@ layout: post
 title: ‘Czech Tech Saving Lives’ - Inaugural Missing Maps hackathon for Czech Republic. A national first.
 postID: hackaton-czech-republic
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191025_one-click-hacking-team.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191025_one-click-hacking-team.jpg
 date: 2019-10-25
 author: Rupert Allen
 excerpt: How many more lives could be safeguarded if a missing mapper only had to click once on a building, rather than once in each corner? What if last month’s release of the Mapswipe 2.0 app could also directly send identified buildings straight to OSM? These were some of the challenges posed to hackers this weekend by organisers of the first ever czech Missing Maps Hackathon in Plszen, Czech Republic.
@@ -16,7 +16,7 @@ lang: en
 *How many more lives could be safeguarded if a missing mapper only had to click once on a building, rather than once in each corner? What if last month’s release of the Mapswipe 2.0 app could also directly send identified buildings straight to OSM? These were some of the challenges posed to hackers this weekend by organisers of the first ever czech Missing Maps Hackathon in Plszen, Czech Republic.*
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191025_techheaven.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191025_techheaven.jpg">
 <p class="caption">Hackers in ‘their dungeon’. The hackaton was hosted and catered for by local ITNGO in their building by the river, around the corner from the Pilsner Urquell brewery museum.</p>
 </figure>
 
@@ -29,7 +29,7 @@ Introducing tech hackers to the way Missing Maps works is always fun. They quick
 Pilsen is the home of many famous technologies, and is quickly evolving into a stronghold of the digital revolution. 3000 developers are estimated to live in this small but beautiful city. From these, a small group of digital humanitarians gathered around some important technical problems, less in competition than collaboration, to see if they could make Open Source field and remote mapping easier. Czech Tech is big business here, and Hackathons often attract decent prizes, all-night red-eyed coding, and copious amounts of caffeine. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191025_old-school-hardware.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191025_old-school-hardware.jpg">
 <p class="caption">Some of the hackers turned up with some serious old-school hardware.</p>
 </figure>
 
@@ -44,14 +44,14 @@ And so the night began.
 The ‘Mapathon Dashboard’ was one such challenge which interested local hackers Adam, Michal and Matyas. Bad quality data can lead to misdirection in the field, but is also crucial for good advocacy, which can show local decision-makers that OSM is a rigorous process, upon which lives and decision liabilities can depend. Many of us are familiar with the [CartOng Mapathon Dashboard](http://mapathon.cartong.org/), but what if we could see some kind of ‘live conversation’ taking place between good and bad data, involving and mentoring more mappers to validate and to up the quality of their original inputs?'
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191025_mapathon-dashboard.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191025_mapathon-dashboard.png">
 <p class="caption">The CartOng mapathon dashboard.</p>
 </figure>
 
 By the end of the weekend, the dashboard had been re-coded to include a live-graph of validated data moment-by-moment, ways to interact validators with their mappers, and some other excellent new features to be proposed to its originators, Missing Maps partners CartOng.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191025D_dashboard-hacking-team.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191025D_dashboard-hacking-team.jpg">
 <p class="caption">The dashboard hacking team.</p>
 </figure>
 
@@ -60,7 +60,7 @@ By the end of the weekend, the dashboard had been re-coded to include a live-gra
 A lot of work has been done on remote sensing for deforestation, drought and flood at low-resolution, but Jakub, Jan and David started building on algorithms from this kind of land-cover data, with an imagery analysis tool, detecting the circles and squares of new ‘shelters’ in unexpected areas, alerting us to previously unknown expanding population -  areas of ‘new human activity’ where unexpected and rapid crisis-mapping is needed.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191025_village-growth-hacking-team.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191025_village-growth-hacking-team.jpg">
 <p class="caption">The village and settlement growth awareness tool hacking team.</p>
 </figure>
 
@@ -71,7 +71,7 @@ There is an ever-increasing need for validation in mapathons, and the basic mapp
 Martin and Jiri tackled this one, which is set to be a ground-breaking change in mapping practice all over the world. Machine learning is all very well, but the human touch will arguably always be needed. And the validation process should be where we focus our remote-mapping time.  After significant advances in ‘the dungeon’ over the weekend, it is now very nearly possible to click only once rather than four times on a building, potentially speeding-up mapping four times over. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191025_one-click-hacking-team.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191025_one-click-hacking-team.jpg">
 <p class="caption">The one-click wonder hacking team.</p>
 </figure>
 
@@ -82,7 +82,7 @@ ODK and Kobo are free smartphone apps which are used almost everywhere in the gl
 ‘The Three Jans’ made significant inroads into a JOSM plugin which could load raw data directly from the field, to be processed simply and effectively, cleaned, validated and conventionalised for upload into OSM.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191025_field-data-hacking-team.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191025_field-data-hacking-team.jpg">
 <p class="caption">The field data streamlining hacking team.</p>
 </figure>
 

--- a/2019-11-27-happy-birthday.md
+++ b/2019-11-27-happy-birthday.md
@@ -3,7 +3,7 @@ layout: post
 title: ‘Happy 5th Birthday!’ - Missing Maps Turns 5 & the Launch of A Year of Blogs! 
 postID: happy-birthday
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191127_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191127_banner.jpg
 date: 2019-11-27
 author: Rachel Levine for the Missing Maps Group
 excerpt: Reflections on 5 Years of Mapping
@@ -19,7 +19,7 @@ Happy Birthday Mappers! It seems like just yesterday that the Missing Maps Proje
 As of this month, over 95,000 of you have contributed to OpenStreetMap to support humanitarian projects around the world. You’ve hosted thousands of volunteer events, consumed millions of slices of pizza, and produced some truly amazing [map-cakes](https://www.pinterest.co.uk/TheMissingMaps/mappy-cake/).
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191127_cake.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191127_cake.png">
 <p class="caption">Cakes at the 5th Birthday Mapathon in London.</p>
 </figure>
 
@@ -49,7 +49,7 @@ Together, we’ve accomplished such amazing things.  When we first organized the
 
 The Heidelberg Institute for Geoinformation Technology/ GIScience Research Group developed a workflow to measure the impact of our Missing Maps project and to evaluate the mapping process and its quality by making use of the HOT Tasking Manager API and their ohsome OpenStreetMap History Data Analysis Framework. Results show that over the years, over 95,000 volunteers finished 2,150 buildings and landuse projects. For further information see [here](https://drive.google.com/file/d/1xIiUJDrdtb5u_fpwrv7BagJFJ7u9uXQg/view).
 
-![animated GIF of 5 years of Missing Maps edits](https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191127_5years.gif)
+![animated GIF of 5 years of Missing Maps edits](https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191127_5years.gif)
 
 The team will for sure also provide further updates to help us better monitor our achievements in the future. 
 

--- a/2019-12-09-a-year-of-blogs.md
+++ b/2019-12-09-a-year-of-blogs.md
@@ -3,7 +3,7 @@ layout: post
 title: "‘OpenStreetMap and MapAction post Hurricane Dorian’ - A Year of Blogs - December 2019"
 postID: a-year-of-blogs-dec2019
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191209_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191209_banner.jpg
 date: 2019-12-09
 author: Alice Goudie
 excerpt: Open Street Map and MapAction post Hurricane Dorian

--- a/2020-01-29-a-year-of-blogs.md
+++ b/2020-01-29-a-year-of-blogs.md
@@ -3,7 +3,7 @@ layout: post
 title: "‘Burundi anti-malaria campaign: Covering the gap’ - A Year of Blogs - January 2020"
 postID: a-year-of-blogs-jan2020
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200129_BurundiMap.PNG
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200129_BurundiMap.PNG
 date: 2020-01-29
 author: Jana Bauerová
 excerpt: "More than two thirds of Burundi’s 11-million population reportedly suffered from malaria since January 2019. Médecins Sans Frontières / Doctors Without Borders (MSF) has contained the disease from spreading in eastern Burundi with an indoor residual spraying (IRS) campaign to protect some 300,000 inhabitants for months to come from the malaria-carrying mosquitoes."

--- a/2020-02-28-a-year-of-blogs.md
+++ b/2020-02-28-a-year-of-blogs.md
@@ -3,7 +3,7 @@ layout: post
 title: "'MapSwipe: An Award Winner' - A Year of Blogs - February 2020"
 postID: a-year-of-blogs-feb2020
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20191001_mapswipe-grid.png
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20191001_mapswipe-grid.png
 date: 2020-02-28
 author: Johnny Henshall
 excerpt: "This week MapSwipe was awarded Best Mobile Innovation Supporting Emergency or Humanitarian Situations in the Tech4Good category at GSMA’s Global Mobile (GLOMO) awards. As a volunteer-led and open-source project, built and maintained by a small but passionate team, we are extremely proud of this recognition amongst other esteemed projects in this category and the rest of the awards."
@@ -18,7 +18,7 @@ lang: en
 MapSwipe is a mobile app that allows anyone to contribute to Missing Maps using just their phone. Swipe through satellite imagery at home or on the go, identifying areas where there is crucial infrastructure, such as buildings and roads. The results help humanitarian organisations to take action where people need it most.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200228_longerbanner.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200228_longerbanner.png">
 </figure>
 
 This week, [MapSwipe was awarded](https://www.mwcbarcelona.com/glomos/mapswipe-formapswipe/) Best Mobile Innovation Supporting Emergency or Humanitarian Situations in the Tech4Good category at GSMA’s Global Mobile (GLOMO) awards. As a volunteer-led and open-source project, built and maintained by a small but passionate team, we are extremely proud of this recognition amongst other esteemed projects in this category and the rest of the awards. The judges said:
@@ -27,7 +27,7 @@ This week, [MapSwipe was awarded](https://www.mwcbarcelona.com/glomos/mapswipe-f
 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200228_award.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200228_award.png">
 </figure>
 
 The award tops off what has been an exciting time for MapSwipe since the [release of version 2.0](http://www.missingmaps.org/blog/2019/10/01/MapSwipe-v2/) just five months ago. Our users have been racing through projects, often quicker than we can add them and have now swiped through a staggering 850 000km2 of imagery – that’s more than the area of Mozambique! We piloted a new project type aimed at detecting changes in areas, had new volunteers get involved with the design and development of the app, and have a vision of what next.
@@ -37,7 +37,7 @@ The award tops off what has been an exciting time for MapSwipe since the [releas
 MapSwipe makes that mindless time on your phone productive. The results of swiping are used to focus Missing Maps volunteer’s efforts by filtering out areas with no features. For our experienced mappers, you’ll appreciate that MapSwipe reduces those times that you’ve spent ages looking through uninhabited forest or desert just looking for features to map.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200228_example.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200228_example.png">
 </figure>
 
 The impact of this is much quicker mapping for you, our Missing Maps volunteers, who are actually adding data to OpenStreetMap and mapping communities that would otherwise not be on the map. For example, with the help of MapSwipe, in just five days, 186 volunteers mapped more than 1,000 sq. km of Port au Prince, Haiti, identifying communities that previously were not included on the map and allowing MSF to create a surveying plan that was truly representative of the population. [You can read more here.](http://www.missingmaps.org/blog/2018/06/25/mapswipe-story/)

--- a/2020-03-31-a-year-of-blogs.md
+++ b/2020-03-31-a-year-of-blogs.md
@@ -3,7 +3,7 @@ layout: post
 title: "'Missing Maps in Canada? Canadian Red Cross Community Mapping' – A Year of Blogs – March 2020"
 postID: a-year-of-blogs-mar2020
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200331_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200331_banner.jpg
 date: 2020-03-31
 author: Melanie Chabot
 excerpt: "The Canadian Red Cross Society’s Missing Maps activities in rural, remote and Indigenous communities."
@@ -17,7 +17,7 @@ lang: en
 The Canadian Red Cross Society became a member of Missing Maps Project in 2017. Our goal was to partner with rural, remote and Indigenous communities in Canada and improve their available maps to increase their resiliency when faced with emergencies. A two-year pilot project to test out this goal is wrapping up at the end of this month – March 2020. The pilot project is part of an ongoing commitment to working alongside communities to increase disaster preparedness and resiliency.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200331_photo1.JPG">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200331_photo1.JPG">
 <p class="caption"> Mapping an educational trail with a pilot community.</p>
 </figure>
 
@@ -32,7 +32,7 @@ This issue is compounded in Indigenous communities, which are greatly underrepre
 The lack of accessible maps for rural, remote and Indigenous communities poses a safety issue when they are faced with emergencies and natural disasters. When these communities face large emergencies, they are often supported by emergency responders from outside of the community. These outsiders are likely very unfamiliar area and would have a difficult time navigating without a map. If an ambulance driver is looking for a house in an unfamiliar rural community, navigating without a map can significantly increase the response time. Furthermore, cell phone coverage in these areas is often unreliable which causes further delays in emergency response.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200331_photo2.JPG">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200331_photo2.JPG">
 <p class="caption"> Field mapping with a pilot community in an area that is recovering from a severe wildfire.</p>
 </figure>
 

--- a/2020-04-30-a-year-of-blogs.md
+++ b/2020-04-30-a-year-of-blogs.md
@@ -3,7 +3,7 @@ layout: post
 title: "'Leveraging Missing Maps for The Community Epidemic and Pandemic Preparedness Program (CP3) in Guinea' – A Year of Blogs – April 2020"
 postID: a-year-of-blogs-apr2020
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200430_longerbanner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200430_longerbanner.jpg
 date: 2020-04-30
 author: Jennifer Duong, David Luswata, and Tino Toupane
 excerpt: "In recent months, the Guinean Red Cross Society and the Community Epidemic and Pandemic Preparedness Program (CP3) teams created their own map data, tracing remotely in OSM and via field data collection. The staff and volunteers involved gained valuable insight in how information is compiled and shared from OSM and other open source platforms."
@@ -14,16 +14,16 @@ lang: en
 ---
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200430_Image1.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200430_Image1.png">
 <p class="caption"> [Image 1: Two participants gathering building information during field data collection]</p>
 </figure>
 
 The ultimate goal of the [Community Epidemic and Pandemic Preparedness Program (CP3)](https://media.ifrc.org/ifrc/community-epidemic-pandemic-preparedness), a program led by the International Federation of the Red Cross (IFRC), is to strengthen the ability of communities and civil society groups to prevent, detect, and respond to disease threats and play a central and significant role in assessing future risks.
 
-[Data Readiness](https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_CP3_data_readiness_1pager.pdf) is one priority and workstream within CP3. Through this workstream, we want national societies to be equipped to use quality and timely information to influence operations and planning; this is all with the goal of being able to respond effectively to disasters. CP3 relies on the methods and community engagement from the Missing Maps program to create base mapping data for many of the communities where CP3 is active.
+[Data Readiness](https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_CP3_data_readiness_1pager.pdf) is one priority and workstream within CP3. Through this workstream, we want national societies to be equipped to use quality and timely information to influence operations and planning; this is all with the goal of being able to respond effectively to disasters. CP3 relies on the methods and community engagement from the Missing Maps program to create base mapping data for many of the communities where CP3 is active.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200430_Image2.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200430_Image2.png">
 <p class="caption"> [Image 2: Map of Faranah by David Luswata]</p>
 </figure>
 
@@ -41,7 +41,7 @@ Over the past several months, the CP3 team and the Guinean Red Cross Society (GR
 The three phases of community mapping are outlined below followed by the takeaway points of the project:
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200430_Image3.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200430_Image3.png">
 <p class="caption"> [Image 3: Guinean Red Cross Society members and volunteers from Geo-synapses gather for a mapathon in Conakry]</p>
 </figure>
 
@@ -68,7 +68,7 @@ Staff and volunteers from the various organizations (most notably from the GRCS 
 <span class="caption">[Table 1 showing remote mapping statistics in Faranah prefecture courtesy of Tino Toupane]</span>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200430_Image4.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200430_Image4.png">
 <p class="caption">[Image 4: A picture of the participants taken from the 4-day field data collection training.]</p>
 </figure>
 

--- a/2020-05-29-a-year-of-blogs.md
+++ b/2020-05-29-a-year-of-blogs.md
@@ -3,7 +3,7 @@ layout: post
 title: "'Developing baseline health facility data with Healthsites' – A Year of Blogs – May 2020"
 postID: a-year-of-blogs-may2020
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200529_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200529_banner.jpg
 date: 2020-05-29
 author: Mark Herringer
 excerpt: "In this article we concentrate on Human Centered Design and how you can help us to build a platform that meets the needs of the people using it."
@@ -17,7 +17,7 @@ lang: en
 # Human Centered Design to drive the development of baseline health facility data with Healthsites – A Year of Blogs – May 2020
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200529_photo1.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200529_photo1.png">
 <p class="caption"> Mapping health facilities in Saint Louis, Senegal  <a href="https://twitter.com/lamineyasey/" target="\_blank">@lamineyasey</a> </p>
 </figure>
 

--- a/2020-07-29-a-year-of-blogs.md
+++ b/2020-07-29-a-year-of-blogs.md
@@ -16,7 +16,7 @@ lang: en
 “I realized right after the French lockdown that online mapathons were very important to me during this isolation period. At first, it was a dedicated time during which I could talk with a lot of people. I especially appreciated the fact that we weren't just talking about COVID-19. It allowed me to connect with new people with shared interests such as cartography or GIS, which represents a proper treat for me since such topics are quite specific. We discussed other topics, such as biodiversity and cooking; it was a precious time to think about something else and relax.” - Feedback from a volunteer at a mapathon with [CartONG](https://www.cartong.org/) For full quote, see below.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200729_photo1.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200729_photo1.png">
 <p class="caption"> [The Missing Maps team wishes you a happy virtual mapathon!]</p>
 </figure>
 

--- a/2020-08-28-a-year-of-blogs.md
+++ b/2020-08-28-a-year-of-blogs.md
@@ -3,7 +3,7 @@ layout: post
 title: "'The State of OpenStreetMap in Africa' – A Year of Blogs – Aug 2020"
 postID: a-year-of-blogs-aug2020
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200828_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200828_banner.jpg
 date: 2020-08-28
 author: Geoffrey Kateregga
 excerpt: "In this article we concentrate on Human Centered Design and how you can help us to build a platform that meets the needs of the people using it."
@@ -18,7 +18,7 @@ lang: en
 OpenStreetMap Africa is a network of OSM communities from all over Africa working together to grow OSM on the continent. Ahead of the [State of the Map 2020](https://2020.stateofthemap.org/) conference, which was supposed to take in place in Africa for the first time, but was held online due to COVID-19, OSM Africa surveyed OSM community leaders in different countries in Africa, to assess the state of OSM in their countries. The purpose of the survey was to see where we are as OSM Africa, where we need to be, and how we can focus on achieving our goal to map each and every corner of Africa. We heard back from 52 out of the 55 countries in Africa and the results were [presented at the conference](https://youtu.be/gHqmQp7gbqE).
  
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200828_photo1.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200828_photo1.png">
 <p class="caption"> The brightest spots on the map above illustrate substantial amounts of OSM node density in different places in Africa.  <a href="https://tyrasd.github.io/osm-node-density/#4/3.03/-0.70/latest,places" target="\_blank">OSM Node Density</a> </p>
 </figure>
  
@@ -27,7 +27,7 @@ OpenStreetMap Africa is a network of OSM communities from all over Africa workin
 We also looked at the population in comparison to the number of mapped objects, to measure map completeness in each country.  This shows Eswatini, Lesotho, Seychelles, Botswana and Zimbabwe as the most mapped countries. [Map Lesotho](https://www.maplesotho.com/) is an interesting case where the Government is leading in the use of OSM for rural and urban planning.
  
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200828_photo2.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200828_photo2.png">
 <p class="caption"> Population in comparison to the number of mapped objects. </p>
 </figure>
  
@@ -36,7 +36,7 @@ We also looked at the population in comparison to the number of mapped objects, 
 Sixty-five percent of the countries that participated in the survey indicated there is an OSM community in their country, although the levels of activity differ from country to country, from very active to inactive. It is also interesting to note some countries like Egypt and Morocco where there is active mapping but no single community. 
  
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200828_photo3.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200828_photo3.png">
 <p class="caption"> Existing OSM communities. </p>
 </figure>
  
@@ -92,7 +92,7 @@ For all the challenges faced, there are solutions which have worked in some coun
 One of the major challenges, pointed out in the survey was lack of access to funds for internet access and other things. Yet communities in only 11 countries from Africa applied for the OSMF Microgrants this year! For the countries with no applications, some had communities that were not aware of the call for applications or no active community to begin with. For others there was just a lack of capacity, with no team to work on a proposal, and a few felt they had no need for a microgrant.
  
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200828_photo4.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200828_photo4.png">
 <p class="caption"> OSMF microgrant applicants.. </p>
 </figure>
  

--- a/2020-09-24-a-year-of-blogs.md
+++ b/2020-09-24-a-year-of-blogs.md
@@ -3,7 +3,7 @@ layout: post
 title: "'Anticipating and addressing epidemics' – A Year of Blogs – Sept 2020"
 postID: 2020-09-24-a-year-of-blogs
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200924_banner.JPG
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200924_banner.JPG
 date: 2020-09-24
 author: Katharina Lorenz
 excerpt: "In order for FbF to work, we need to decide quickly, when and where to act."
@@ -43,7 +43,7 @@ The types of features being mapped vary based on the local needs, but can includ
 In [Botswana](https://hotosm.us9.list-manage.com/track/click?u=5191e27b207136970f2a9ec1b&id=0fc5623a76&e=12fee999b0), HOT has been mapping at the request of the Botswana Institute of Geoinformatics to support the national COVID-19 response. While the mapping of the initial priority region has been completed, efforts are now expanding to map the entire country in OSM.
 
 In [Mali](https://hotosm.us9.list-manage.com/track/click?u=5191e27b207136970f2a9ec1b&id=885ea70ba0&e=12fee999b0), HOT is supporting the COVID-19 coalition, which includes members of the local OpenStreetMap community and the Mali Red Cross, so they can better plan and respond to coronavirus impacts.
-<figure> <img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200924_MaliMappingCovid.jpg"> <p class="caption"> HOT mapping task supporting COVID-19 response in Mali.</p> </figure>
+<figure> <img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200924_MaliMappingCovid.jpg"> <p class="caption"> HOT mapping task supporting COVID-19 response in Mali.</p> </figure>
 
 In [Peru](https://hotosm.us9.list-manage.com/track/click?u=5191e27b207136970f2a9ec1b&id=0a0f40644b&e=12fee999b0), HOT has mapped the entire Cusco region, home to 1.2 million people and with extremely varied terrain; from Altiplano communities living at 5,000m altitude to Amazonian jungle. Creating better maps has allowed government workers to begin using the data to assess healthcare needs. This is particularly vital for maternal healthcare services, which have been largely unavailable over the past few months due to quarantine. For more information please check out this [blog](https://www.hotosm.org/updates/covid-19-pandemic-in-peru-mapping-health-implications/).
 
@@ -60,7 +60,7 @@ The Heidelberg Institute for Geoinformation Technology (HeiGIT gGmbH), also a Mi
 To enable awareness of local health capacities and building on the data created through HOT efforts, in the scope of the COVID-19 response the HeiGIT team developed an extension of their [OSM History Explorer](https://ohsome.org/apps/osm-history-explorer/#/amenity_clinic_healthcare_clinic_ptpl/2020-06-01T00:00:00Z/2/0/0) (ohsome hex) which allows analyses of OSM completeness in mapping health facilities in Sub-Saharan Africa. This extension facilitates quick and simple assessment of health facilities in areas of interest and to respectively raise awareness of vulnerable areas. 
 
 Additionally, the team conducted several related research studies and developed a [“Map of Hope”](https://covid-19.heigit.org/clinical_trials.html) that provides a comprehensive overview of COVID-19 related clinical trials, using OSM as a base layer for localization. 
-<figure> <img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20200924_Explorer.JPG"> <p class="caption"> OSM History Explorer showing completeness of health facilities in sub-saharan Africa.</p> </figure>
+<figure> <img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20200924_Explorer.JPG"> <p class="caption"> OSM History Explorer showing completeness of health facilities in sub-saharan Africa.</p> </figure>
 
 ## What next? ##
 

--- a/2020-10-26-a-year-of-blogs.md
+++ b/2020-10-26-a-year-of-blogs.md
@@ -3,7 +3,7 @@ layout: post
 title: "Missing Maps Project awarded at the Red Cross Humanitarian Technology Awards – A Year of Blogs – Oct 2020"
 postID: 2020-10-26-a-year-of-blogs
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20201027_banner.jpg
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20201027_banner.jpg
 date: 2020-10-26
 author: Paul Knight
 excerpt: "Back in February, the Missing Maps Project was awarded the Cruz Roja Award at the Red Cross Humanitarian Technology Awards (IV Edition)"
@@ -16,7 +16,7 @@ lang: en
 Back in February, the Missing Maps Project was awarded the Cruz Roja Award at the [Red Cross Humanitarian Technology Awards (IV Edition)](https://www2.cruzroja.es/premios-tecnologia-humanitaria).
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20201026_photo2.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20201026_photo2.png">
 </figure>
 
 The Red Cross Humanitarian Technology Awards (IV Edition) are awards that promote the humanitarian use of technology to build a better world and are awarded to developments which promote the humanitarian use of technology.
@@ -24,7 +24,7 @@ The Red Cross Humanitarian Technology Awards (IV Edition) are awards that promot
 The Missing Maps Project members are delighted to have been awarded the Cruz Roja Award, and are proud to stand alongside the other award winners, whose projects, ideas and prototypes demonstrate the power of emerging technology for humanitarian action.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20201026_photo1.jpg">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20201026_photo1.jpg">
 </figure>
 
 We are incredibly honoured to be part of a passionate, humanitarian network of mappers who have created to this technology and community. This award belongs to all the volunteers, community groups and contributors who make the objectives and ethics that the Missing Maps Project stands for come to life.
@@ -34,7 +34,7 @@ We are incredibly honoured to be part of a passionate, humanitarian network of m
 *Get involved in OpenStreetMap GeoWeek with the Red Cross Red Crescent network and map for preparedness programmes!*
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20201026_photo.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20201026_photo.png">
 </figure>
 
 This 15th — 21st November is [OpenStreetMap GeoWeek](https://osmgeoweek.org/index.html), bringing together community groups, map enthusiasts, humanitarians and others to celebrate geography. During the week we’ll create maps with OpenStreetMap (OSM), the free, open source map of the world that the Missing Maps Project contributes to and uses to build maps for programmes and preparedness.

--- a/2020-11-24-a-year-of-blogs.md
+++ b/2020-11-24-a-year-of-blogs.md
@@ -3,7 +3,7 @@ layout: post
 title: "Help to Grow MapSwipe by Joining the Collective – A Year of Blogs – Nov 2020"
 postID: 2020-11-24-a-year-of-blogs
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20201124_photo.png
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20201124_photo.png
 date: 2020-11-24
 author: Laurent Savaëte
 excerpt: "Why we're setting up a collective to support MapSwipe"

--- a/2020-12-28-a-year-of-blogs.md
+++ b/2020-12-28-a-year-of-blogs.md
@@ -3,7 +3,7 @@ layout: post
 title: "The Maps may be Missing, but We are Still Here – A Year of Blogs – Dec 2020"
 postID: 2020-12-28-a-year-of-blogs
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20201228_banner.png
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20201228_banner.png
 date: 2020-12-28
 author: David Garcia 
 excerpt: "International cooperation in mapping is important, but who is really leading?"
@@ -22,14 +22,14 @@ How should you map seas of islands in the Pacific? The region, like others in th
 As humanitarian mapping and other major geospatial projects continue in Moana Oceania, also known as the Pacific, it should be remembered that we the people who are born and raised in this ocean and its islands are descendants of the greatest navigators, the [Austronesians](https://en.wikipedia.org/wiki/Austronesian_peoples). I am of the Kapampangan and Tagalog peoples who descend from Luzon Island, which is part of the seas of islands of Pilipinas (the Philippines). The map below depicts a migration of my ancestors and their relatives from Taiwan to the regions of Madagasikara (Madagascar), Aotearoa (New Zealand), and beyond. They accomplished this by observing the waves, winds, stars, birds, and many other signs; inventing seafaring technologies; and taking care of communities along the way. They were mapmakers, [from whom western colonisers borrowed expertise](https://en.wikipedia.org/wiki/Enrique_of_Malacca) during the colonisation of the ocean, which continues today.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20201228_photo1.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20201228_photo1.png">
 <p class="caption"> Figure 1. The Austronesian migration <a href="https://www.researchgate.net/figure/Map-outlining-migratory-paths-of-Austronesian-speaking-populations-including-estimated_fig1_224709266" target="\_blank">credit</a></p>
 </figure>
 
 Hence before you proceed, please be aware that my way of reasoning and aspiring may seem tautological and mundane. But the reader must recognise that I descend from and tap into an oceanic wayfinding culture that regards spacetime as cyclical, recursive, and highly relational. This means that the past is in front of us while the future is behind us in an ever-living present. In international buzzwords, it is called “iteration” and “networking”. This also means that I draw from an intergenerational body of geographic knowledge that is not limited by shapefiles or map tiles. For example, our relatives in what was called Micronesia, which is in fact a group of large ocean states, have been making maps about the relationships between seas of islands for a very long time.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20201228_photo2.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20201228_photo2.png">
 <p class="caption"> Figure 2. An ocean chart by Indigenous wayfinders of Micronesia <a href="https://www.nationalgeographic.org/media/micronesian-stick-chart/" target="\_blank">credit</a></p>
 </figure>
 
@@ -38,7 +38,7 @@ We know where we are going because we know where we came from. This means that o
 If you look at history and geography with a deep sense of time and space, then you will know this important truth: we are not missing from the maps. In fact, we have been overmapped. For hundreds of years, Western cartographers and ethnographers have been profiling our interrelated peoples, absurdly slicing the ocean, and concocting controversial racial hierarchies and questionable regional categories. These problematic patterns persist until today, whether in outputs or organisations who do the mapping and storytelling. [Mapping has been very troublesome](https://thebaffler.com/latest/the-map-and-the-territory-aguilar-gil). And while maps may be missing from digital platforms and social networks, we are still here.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20201228_photo3.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20201228_photo3.png">
 <p class="caption"> Figure 3. A racialised and segregated 1832 map of Oceania, made by the cartographer, explorer, and coloniser Dumont d’Urville </p>
 </figure>
 
@@ -51,11 +51,11 @@ How can we avoid such harms in the production of geospatial knowledge, especiall
 Last year, we hosted a mapathon here in Aotearoa, also known as New Zealand, for mapping seas of islands here in our ocean. The event, organised with the support of [FOSS4G-SotM Oceania 2019](https://www.osgeo.org/events/foss4g-sotm-oceania-2019/), was attended by folks of various backgrounds across the large ocean states. We were making maps for, with, and by the Pacific. I acknowledge the Indigenous peoples of Aotearoa for the space and opportunity to do this work, while I follow their leadership in the journey towards the full decolonisation of New Zealand and the rest of the Pacific.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20201228_photo4.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20201228_photo4.png">
 </figure>
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20201228_photo5.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20201228_photo5.png">
 <p class="caption"> Figure 4 and 5. Participants in the Missing Maps mapathon in Wellington, Aotearoa (New Zealand) last November 2019. Photos by conference organisers</p>
 </figure>
 

--- a/2021-01-29-MSF-Malaria-Burundi.md
+++ b/2021-01-29-MSF-Malaria-Burundi.md
@@ -3,7 +3,7 @@ layout: post
 title: "Mobile Methods Minimizing Malaria Cases in Eastern Burundi"
 postID: 2021-01-29-MSF-Malaria-Burundi
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210129_banner.png
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210129_banner.png
 date: 2021-01-29
 author: Jana Bauerova
 excerpt: "Building on the first year of pilot Indoor Residual Spraying campaign, the Médecins Sans Frontières (MSF) recently conducted a second round. Lessons learned could be incorporated during the repeated exercise and results are encouraging."
@@ -23,7 +23,7 @@ In 2019, the number of people who contracted malaria significantly rose in Burun
 It was time to think about how to prevent tiny mosquitoes from transmitting the disease to a sizeable chunk of population. In September 2019, MSF supported the Ministry of Health  in the setting up of a [first round of indoor residual spraying (IRS) campaign](https://www.missingmaps.org/blog/2020/01/29/a-year-of-blogs/). This technique involves spraying individual houses with insecticide to kill off mosquitoes. In one month, the MSF teams sprayed 59,731 homes, protecting close to 287,000 inhabitants for a period estimated up to nine months. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210129_photo4.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210129_photo4.png">
 </figure>
 
 **Spraying at a household level against malaria-carrying mosquitoes**
@@ -31,7 +31,7 @@ It was time to think about how to prevent tiny mosquitoes from transmitting the 
 For the IRS campaign to be effective, it needs to be repeated. In this case, the spraying of the houses in the area would be done every year over the course of three years. That leads to renewing the protection of the households, and lowering the number of malaria-transmitting mosquitoes in the community. A Missing Maps activation had helped to obtain a base map with updated buildings based on recent satellite imagery with help of volunteers before the 1st round of IRS. Once data were available on openstreetmap, the experts in Geographic Information Systems (GIS) and Internet and Communication Technologies (ICT) uploaded the in mobile phones and computers to prepare the IRS Data Collection strategy. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210129_photo1.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210129_photo1.png">
 <p class="caption"> MSF team adding data to phones</p>
 </figure>
 
@@ -40,8 +40,8 @@ To carry out the second round of the IRS campaign meant to mobilize local author
 Overall, 468 sprayers and 330 community health workers were dispatched in the hills to prepare and conduct the campaign. Luckily, over 80% were field workers involved in the first round of the IRS campaign in 2019, so it was possible to do the training over the course of three weeks. Close to 100 local staff were trained in mobile data collection in OSMand and Kobo applications. During the campaign, building information was updated in the mobile mapping applications directly by the team leaders to monitor the progress and compiled always at the end of the day by the GIS expert. 
 
 <p float="left">
-  <img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210129_photo2.png" width="300" />
-  <img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210129_photo3.png" width="300" /> 
+  <img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210129_photo2.png" width="300" />
+  <img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210129_photo3.png" width="300" /> 
   <p class="caption">What a  team leader sees on the mobile screen: Black dots are houses sprayed, yellow yet to be sprayed and red – spraying refused or not possible.</p>
 </p>
 
@@ -54,6 +54,6 @@ According to the GIS Superviser, it was better for the spraying teams to start f
 Even though the second year included new houses, the 2020 campaign succeeded to have a higher coverage than the first year: 311,500 people protected in the three communes (97% of total population), with 98% of the houses sprayed. Thankfully, a tangible impact with a more than 85% reduction of malaria cases in the district following the 2019 intervention made the MSF team usually welcome by the local people. These good results led to the interest of the National Programme to learn from the MSF experience and best practices. The experience shows that the desired results may be reached, but require a complex planning, logistics and considerable human resources including the training and a multi-year implementation with use of the Geographic Information Systems.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210129_photo5.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210129_photo5.png">
 <p class="caption"> Spraying equipment is quite heavy!</p>
 </figure>

--- a/2021-02-15-MapSwipe-WB.md
+++ b/2021-02-15-MapSwipe-WB.md
@@ -3,7 +3,7 @@ layout: post
 title: "Leveraging MapSwipe to improve solid waste management in Mali: Sustaining livelihoods amidst COVID-19 shutdowns."
 postID: 2021-02-15-MapSwipe-WB
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210215_banner.png
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210215_banner.png
 date: 2022-02-15
 author: Jessica Bergmann
 excerpt: "Sustaining livelihoods amidst COVID-19 shutdowns using MapSwipe. In Bamako, Mali, more than 100 individuals whose livelihoods were affected due to COVID-19 participated in the pilot program."
@@ -24,7 +24,7 @@ And as waste continues to build in urban and peri-urban areas of Bamako, it pose
 
 So how can local authorities begin to solve a problem they cannot fully measure and characterize? We started by generating data to help visualize the problem.
 
-![animated GIF MapSwipe Demo](https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_2021128_mapswipe.gif)
+![animated GIF MapSwipe Demo](https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_2021128_mapswipe.gif)
 
 With high resolution aerial imagery of Bamako, community members were trained on how to identify collections of solid waste using MapSwipe on their mobile phones. Together, they spent over 1,500 hours swiping through 6,000,000 imagery tiles and indicating where solid waste in the city was without ever having to leave their home and helping to ensure their safety amidst COVID-19. All individuals received payment for completing the microtasks, helping to offset some of the economic shock they experienced because of COVID restrictions.
 
@@ -33,7 +33,7 @@ With high resolution aerial imagery of Bamako, community members were trained on
 And the data generated was a clear success. In under two weeks, users swiped an area of over 450 square kilometers, producing some of the highest quality, detailed data ever produced by MapSwipe. 
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210215_photo2.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210215_photo2.png">
 </figure>
 
 The data has already been used at the city level to start visualizing where waste is being generated and dumped and to plan where to distribute facilities to collect waste before it is dumped in streets and vacant lots. A small study has also been commissioned to track small enterprises that are collecting waste in communities through door-to-door service; map layers will show routes of these waste collectors overlaid on a map of the piles of solid waste to help city officials and small enterprises improve service provision through better planning.

--- a/2021-04-29-Website-Update.md
+++ b/2021-04-29-Website-Update.md
@@ -3,7 +3,7 @@ layout: post
 title: "Missing Maps Website Upgrade!"
 postID: 2021-04-29-Website-Update
 category: blog
-banner: https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210429_banner.png
+banner: https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210429_banner.png
 date: 2021-04-29
 author: Melanie Chabot & Rachel Levine
 excerpt: "We are so excited to announce the launch of our refreshed website! Over the last year, the Missing Maps team has focused on this project to ensure that you, our wonderful mappers, have everything you need to best participate in the OSM Community."
@@ -40,5 +40,5 @@ We are so excited to share what we’ve already accomplished, but we know there 
 **Happy Mapping!**
 
 <p align="center">
-  <img width="460" height="300" src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210429_photo1.png">
+  <img width="460" height="300" src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210429_photo1.png">
 </p>

--- a/2021-05-26-community-mapping.md
+++ b/2021-05-26-community-mapping.md
@@ -3,7 +3,7 @@ layout: post
 title: "Mapping Your Own Backyard: Stories from Local Community Mappers"
 postID: 2021-05-26-community-mapping
 category: blog
-banner: "https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210526_Banner.png"
+banner: "https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210526_Banner.png"
 date: 2021-05-26
 author: Melanie Chabot, Rachel Levine & Jorieke Vyncke
 excerpt: We have collected the stories of several enthusiastic OSM-ers who have mastered the art of mapping their own backyards. They have offered their advice for those who are first starting out and shared the reasons why they have become so passionate about local mapping.
@@ -30,7 +30,7 @@ We have collected the stories of several enthusiastic OSM-ers who have mastered 
 ### Herry Kasunga, Tanzania
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210526_Herry.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210526_Herry.png">
 <p class="caption"> Herry Kasunga mapping his community using the <a href="https://maps.me/" target="\_blank">Maps.me application</a> on his Smartphone. This mapping will later support planning activities to help girls who are in vulnerable places (such as those at risk of undergoing female genital mutilation).</p>
 </figure>
 
@@ -45,7 +45,7 @@ We have collected the stories of several enthusiastic OSM-ers who have mastered 
 ### Gregory Marler, United Kingdom
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210526_Gregory.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210526_Gregory.png">
 <p class="caption"> Gregory at the top of a hill overlooking Pittington. This is a village that he attempted to survey all in one go! It was much snowier and colder than he thought he could cope with. The adventure was filmed for his <a href="https://www.youtube.com/watch?v=dFxDTp_1rEo" target="\_blank">"Mapper Diaries"</a> channel on YouTube, which is a bit like walking alongside Gregory as he goes about his typical mapping.</p>
 </figure>
 
@@ -60,7 +60,7 @@ We have collected the stories of several enthusiastic OSM-ers who have mastered 
 ### Matthew Darwin, Canada
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210526_Matthew.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210526_Matthew.png">
 <p class="caption"> Matthew on a bike trip in the Florida keys. He biked from mile marker 80 all the way to 0!</p>
 </figure>
 
@@ -69,7 +69,7 @@ We have collected the stories of several enthusiastic OSM-ers who have mastered 
 **Ideal day mapping?** Ottawa is now fairly well mapped due to a lot of great City of Ottawa open data as well as a huge volunteer effort.  So work is mostly about completing missing areas. When I started, there were lots of messy things which I spent many months helping to clean up. I spent a lot of time on street naming. Effort is put into active transportation infrastructure such as paths, bike parking, water fountains as well as addresses for new or updated areas of the city. I spend most of my time mapping in the car or on a bike taking photos for [Mapillary](https://www.mapillary.com/). The tools I use include: [JOSM](https://josm.openstreetmap.de/), [Mapillary](https://www.mapillary.com/), [Keypad Mapper](https://wiki.openstreetmap.org/wiki/Keypad-Mapper_3) and [Field Papers](http://fieldpapers.org/). I spend a lot of time doing quality assurance on OSM data across Canada - things you can improve without detailed local knowledge such as fixing the formatting of phone numbers, postal codes or fixing the spelling of cities and street names.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210526_Matthew2.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210526_Matthew2.png">
 <p class="caption"> A photo Matthew took last fall from a camera attached to his bike and uploaded to Mapillary. It is a photo of the <a href="https://ottawa.ca/en/city-hall/public-engagement/projects/jackie-holzman-bridge-formerly-harmer-avenue-pedestrian-bridge-replacement" target="\_blank">new bridge</a>  that replaced the bridge he used to go over every day on his way to high school (bike or walking).</p>
 </figure>
 
@@ -80,7 +80,7 @@ We have collected the stories of several enthusiastic OSM-ers who have mastered 
 ### Leigh Lunas, Philippines
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210526_Leigh.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210526_Leigh.png">
 <p class="caption">Leigh showing mapping enthusiasts how to use drone for aerial surveying at Pista ng Mapa in Dumaguete in 2019.</p>
 </figure>
 

--- a/2021-05-26-community-mapping_ES.md
+++ b/2021-05-26-community-mapping_ES.md
@@ -3,7 +3,7 @@ layout: post
 title: "Mapear tu propio patio trasero: historias de mapeadores de comunidades locales!"
 postID: 2021-05-26-community-mapping-es
 category: blog
-banner: "https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210526_Banner.png"
+banner: "https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210526_Banner.png"
 date: 2021-05-26
 author: Melanie Chabot, Rachel Levine & Jorieke Vyncke
 excerpt: Hemos recopilado las historias de varios OSM-ers entusiastas que han dominado el arte de mapear sus propios patios traseros. Han compartido sus consejos para aquellos que están empezando y las razones por las que se han vuelto tan apasionados por la cartografía local.
@@ -28,7 +28,7 @@ Hemos recopilado las historias de varios entusiastas voluntarios de OSM que han 
 ## Herry Kasunga, Tanzania
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210526_Herry.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210526_Herry.png">
 <p class="caption"> Herry Kasunga mapeando su comunidad usando la aplicación <a href="https://maps.me/" target="\_blank">Maps.me application</a> en su teléfono inteligente. Este mapeo apoyará posteriormente las actividades de planificación para ayudar a las niñas que se encuentran en lugares vulnerables (como las que corren el riesgo de sufrir mutilación genital femenina).</p>
 </figure>
 
@@ -45,7 +45,7 @@ Hemos recopilado las historias de varios entusiastas voluntarios de OSM que han 
 ## Gregory Marler, Reino Unido
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210526_Gregory.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210526_Gregory.png">
 <p class="caption"> Gregory en la cima de una colina con vistas a Pittington. ¡Esta es una aldea que intentó inspeccionar de una sola vez! Estaba mucho más nevado y frío de lo que pensaba que podía soportar. La aventura fue filmada para su canal   <a href="https://www.youtube.com/watch?v=dFxDTp_1rEo" target="\_blank">"Mapper Diaries"</a> en YouTube, que es un poco como caminar junto a Gregory mientras realiza su típico mapeo. </p>
 </figure>
 
@@ -60,7 +60,7 @@ Hemos recopilado las historias de varios entusiastas voluntarios de OSM que han 
 ## Matthew Darwin, Canadá
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210526_Matthew.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210526_Matthew.png">
 <p class="caption"> Matthew en un viaje en bicicleta por los cayos de Florida. ¡Condujo en bicicleta desde el marcador de la milla 80 hasta el 0! </p>
 </figure>
 
@@ -69,7 +69,7 @@ Hemos recopilado las historias de varios entusiastas voluntarios de OSM que han 
 **¿Día ideal de mapeo?** Ottawa está ahora bastante bien mapeada debido a una gran cantidad de datos abiertos de la ciudad de Ottawa, así como a un gran esfuerzo voluntario. Por lo tanto, el trabajo consiste principalmente en completar las áreas que faltan. Cuando comencé, había muchas cosas desordenadas que pasé bastantes meses ayudando a limpiar. Pasé mucho tiempo con la nomenclatura de las calles. Se dedica esfuerzo a la infraestructura de transporte activa, como caminos, estacionamiento para bicicletas, fuentes de agua, así como direcciones para áreas nuevas o actualizadas de la ciudad. Paso la mayor parte de mi tiempo haciendo mapas en el auto o en una bicicleta tomando fotos para [Mapillary](https://www.mapillary.com/). Las herramientas que utilizo son: [JOSM](https://josm.openstreetmap.de/), [Mapillary](https://www.mapillary.com/), [Keypad Mapper](https://wiki.openstreetmap.org/wiki/Keypad-Mapper_3) y [Field Papers](http://fieldpapers.org/). Dedico mucho tiempo a garantizar la calidad de los datos de OSM en Canadá: cosas que puedes mejorar sin un conocimiento local detallado, como corregir el formato de números de teléfono, códigos postales o corregir la ortografía de ciudades y nombres de calles.
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210526_Matthew2.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210526_Matthew2.png">
 <p class="caption"> Una foto que Matthew tomó el otoño pasado desde una cámara colocada en su bicicleta y subida a Mapillary. Es una foto del nuevo puente <a href="https://ottawa.ca/en/city-hall/public-engagement/projects/jackie-holzman-bridge-formerly-harmer-avenue-pedestrian-bridge-replacement" target="\_blank">new bridge</a>  que reemplazó al puente que solía cruzar todos los días en su camino a la escuela secundaria (en bicicleta o caminando). </p>
 </figure>
 
@@ -80,7 +80,7 @@ Hemos recopilado las historias de varios entusiastas voluntarios de OSM que han 
 ## Leigh Lunas, Filipinas
 
 <figure>
-<img src="https://arcmaps.s3.amazonaws.com/share/blog-pictures/missingmaps-blog_20210526_Leigh.png">
+<img src="https://github.com/MissingMaps/img/blob/main/images/missingmaps-blog_20210526_Leigh.png">
 <p class="caption">Leigh muestra a los entusiastas de la cartografía cómo usar drones para levantamientos aéreos en Pista ng Mapa en Dumaguete en el 2019. </p>
 </figure>
 


### PR DESCRIPTION
Posts older than 2022 had image links pointing to AWS which are broken. 

This PR changes any AWS links to link to the `MissingMaps/img` repo.

This is a fix for this issue, accidentally posted on the wrong repo: 
https://github.com/MissingMaps/missing-maps-website/issues/30#issuecomment-2832664503